### PR TITLE
[#95] 시간표 도메인의 CRUD 기능을 구현한다.

### DIFF
--- a/src/main/java/com/festival/common/base/BaseEntity.java
+++ b/src/main/java/com/festival/common/base/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.festival.common.base;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedBy
+    private String createdBy;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+}

--- a/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
+++ b/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
@@ -1,4 +1,41 @@
 package com.festival.domain.timetable.controller;
 
+import com.festival.domain.timetable.dto.TimeTableCreateReq;
+import com.festival.domain.timetable.dto.TimeTableDateReq;
+import com.festival.domain.timetable.dto.TimeTableRes;
+import com.festival.domain.timetable.service.TimeTableService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/timetable")
 public class TimeTableController {
+
+    private final TimeTableService timeTableService;
+
+    @PostMapping
+    public ResponseEntity<Long> createTimeTable(@RequestBody TimeTableCreateReq timeTableCreateReq) {
+        return ResponseEntity.ok().body(timeTableService.create(timeTableCreateReq));
+    }
+
+    @PutMapping("/{timeTableId}")
+    public ResponseEntity<Long> updateTimeTable(@PathVariable Long timeTableId,
+                                                @RequestBody TimeTableCreateReq timeTableCreateReq) {
+        return ResponseEntity.ok().body(timeTableService.update(timeTableId, timeTableCreateReq));
+    }
+
+    @DeleteMapping("/{timeTableId}")
+    public ResponseEntity<Void> deleteTimeTable(@PathVariable Long timeTableId) {
+        timeTableService.delete(timeTableId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TimeTableRes>> getTimeTables(@RequestBody TimeTableDateReq timeTableDateReq) {
+        return ResponseEntity.ok().body(timeTableService.getList(timeTableDateReq));
+    }
 }

--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableCreateReq.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableCreateReq.java
@@ -1,0 +1,25 @@
+package com.festival.domain.timetable.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class TimeTableCreateReq {
+
+    @NotNull(message = "시작 시간을 입력 해주세요.")
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간을 입력 해주세요.")
+    private LocalDateTime endTime;
+
+    @NotBlank(message = "제목을 입력 해주세요.")
+    private String title;
+
+    @NotNull(message = "상태를 선택 해주세요.")
+    private String status;
+}

--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableDateReq.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableDateReq.java
@@ -1,0 +1,22 @@
+package com.festival.domain.timetable.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TimeTableDateReq {
+
+    @NotNull(message = "시작 시간을 입력 해주세요.")
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간을 입력 해주세요.")
+    private LocalDateTime endTime;
+
+    @NotNull(message = "상태를 선택 해주세요.")
+    private String status;
+
+    private int offset;
+}

--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableDto.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableDto.java
@@ -1,4 +1,0 @@
-package com.festival.domain.timetable.dto;
-
-public class TimeTableDto {
-}

--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableRes.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableRes.java
@@ -1,0 +1,17 @@
+package com.festival.domain.timetable.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TimeTableRes {
+
+    private String title;
+
+    @QueryProjection
+    public TimeTableRes(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableSearchCond.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableSearchCond.java
@@ -1,0 +1,21 @@
+package com.festival.domain.timetable.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TimeTableSearchCond {
+    
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String status;
+    private int offset;
+
+    public TimeTableSearchCond(LocalDateTime startTime, LocalDateTime endTime, String status, int offset) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.offset = offset;
+    }
+}

--- a/src/main/java/com/festival/domain/timetable/model/TImeTable.java
+++ b/src/main/java/com/festival/domain/timetable/model/TImeTable.java
@@ -1,4 +1,0 @@
-package com.festival.domain.timetable.model;
-
-public class TImeTable {
-}

--- a/src/main/java/com/festival/domain/timetable/model/TimeTable.java
+++ b/src/main/java/com/festival/domain/timetable/model/TimeTable.java
@@ -1,0 +1,64 @@
+package com.festival.domain.timetable.model;
+
+import com.festival.domain.timetable.dto.TimeTableCreateReq;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TimeTable {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TimeTableStatus timeTableStatus;
+
+    @Builder
+    private TimeTable(String title, LocalDateTime startTime, LocalDateTime endTime, TimeTableStatus timeTableStatus) {
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.timeTableStatus = timeTableStatus;
+    }
+
+    public static TimeTable of(TimeTableCreateReq timeTableCreateReq) {
+        return TimeTable.builder()
+                .title(timeTableCreateReq.getTitle())
+                .startTime(timeTableCreateReq.getStartTime())
+                .endTime(timeTableCreateReq.getEndTime())
+                .timeTableStatus(settingStatus(timeTableCreateReq.getStatus()))
+                .build();
+    }
+
+    public void update(TimeTableCreateReq timeTableCreateReq) {
+        this.title = timeTableCreateReq.getTitle();
+        this.startTime = timeTableCreateReq.getStartTime();
+        this.endTime = timeTableCreateReq.getEndTime();
+        this.timeTableStatus = settingStatus(timeTableCreateReq.getStatus());
+    }
+
+    public void changeStatus(TimeTableStatus timeTableStatus) {
+        this.timeTableStatus = timeTableStatus;
+    }
+
+    private static TimeTableStatus settingStatus(String timeTableStatus) {
+        return TimeTableStatus.checkStatus(timeTableStatus);
+    }
+}

--- a/src/main/java/com/festival/domain/timetable/model/TimeTableStatus.java
+++ b/src/main/java/com/festival/domain/timetable/model/TimeTableStatus.java
@@ -15,11 +15,10 @@ public enum TimeTableStatus {
     }
 
     public static TimeTableStatus checkStatus(String status) {
-        for (TimeTableStatus timeTableStatus : TimeTableStatus.values()) {
-            if (timeTableStatus.value.equals(status)) {
-                return timeTableStatus;
-            }
-        }
-        return null;
+        return switch (status) {
+            case "운영중" -> TimeTableStatus.OPERATE;
+            case "종료" -> TimeTableStatus.TERMINATE;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/com/festival/domain/timetable/model/TimeTableStatus.java
+++ b/src/main/java/com/festival/domain/timetable/model/TimeTableStatus.java
@@ -1,0 +1,25 @@
+package com.festival.domain.timetable.model;
+
+import lombok.Getter;
+
+@Getter
+public enum TimeTableStatus {
+
+    OPERATE("운영중"),
+    TERMINATE("종료");
+
+    private String value;
+
+    TimeTableStatus(String value) {
+        this.value = value;
+    }
+
+    public static TimeTableStatus checkStatus(String status) {
+        for (TimeTableStatus timeTableStatus : TimeTableStatus.values()) {
+            if (timeTableStatus.value.equals(status)) {
+                return timeTableStatus;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/festival/domain/timetable/repository/TimeTableRepository.java
+++ b/src/main/java/com/festival/domain/timetable/repository/TimeTableRepository.java
@@ -1,4 +1,7 @@
 package com.festival.domain.timetable.repository;
 
-public class TimeTableRepository {
+import com.festival.domain.timetable.model.TimeTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeTableRepository extends JpaRepository<TimeTable, Long>, TimeTableRepositoryCustom {
 }

--- a/src/main/java/com/festival/domain/timetable/repository/TimeTableRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/timetable/repository/TimeTableRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.festival.domain.timetable.repository;
+
+import com.festival.domain.timetable.dto.TimeTableRes;
+import com.festival.domain.timetable.dto.TimeTableSearchCond;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface TimeTableRepositoryCustom {
+    List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond, Pageable pageable);
+}

--- a/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.festival.domain.timetable.repository.impl;
+
+import com.festival.domain.timetable.dto.QTimeTableRes;
+import com.festival.domain.timetable.dto.TimeTableRes;
+import com.festival.domain.timetable.dto.TimeTableSearchCond;
+import com.festival.domain.timetable.repository.TimeTableRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.festival.domain.timetable.model.QTimeTable.*;
+
+public class TimeTableRepositoryImpl implements TimeTableRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public TimeTableRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond, Pageable pageable) {
+        return queryFactory
+                .select(new QTimeTableRes(
+                        timeTable.title
+                ))
+                .from(timeTable)
+                .where(
+                        isWithinPeriod(timeTableSearchCond.getStartTime(), timeTableSearchCond.getEndTime()),
+                        StatusEq(timeTableSearchCond.getStatus())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private static BooleanExpression isWithinPeriod(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime == null || endTime == null) {
+            return null;
+        }
+        return timeTable.startTime.after(startTime)
+                .and(timeTable.endTime.before(endTime));
+    }
+
+    private static BooleanExpression StatusEq(String status) {
+        return status == null ? null : timeTable.timeTableStatus.stringValue().eq(status);
+    }
+}

--- a/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
+++ b/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
@@ -1,4 +1,55 @@
 package com.festival.domain.timetable.service;
 
+import com.festival.domain.timetable.dto.TimeTableCreateReq;
+import com.festival.domain.timetable.dto.TimeTableDateReq;
+import com.festival.domain.timetable.dto.TimeTableRes;
+import com.festival.domain.timetable.dto.TimeTableSearchCond;
+import com.festival.domain.timetable.model.TimeTable;
+import com.festival.domain.timetable.repository.TimeTableRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.festival.domain.timetable.model.TimeTableStatus.TERMINATE;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class TimeTableService {
+
+    private final TimeTableRepository timeTableRepository;
+
+    @Transactional
+    public Long create(TimeTableCreateReq timeTableCreateReq) {
+        TimeTable timeTable = TimeTable.of(timeTableCreateReq);
+        TimeTable savedTimeTable = timeTableRepository.save(timeTable);
+        return savedTimeTable.getId();
+    }
+
+    @Transactional
+    public Long update(Long timeTableId, TimeTableCreateReq timeTableCreateReq) {
+        TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow();
+        timeTable.update(timeTableCreateReq);
+        return timeTable.getId();
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        TimeTable timeTable = timeTableRepository.findById(id).orElseThrow();
+        timeTable.changeStatus(TERMINATE);
+    }
+
+    public List<TimeTableRes> getList(TimeTableDateReq timeTableDateReq) {
+        TimeTableSearchCond timeTableSearchCond = new TimeTableSearchCond(
+                timeTableDateReq.getStartTime(), timeTableDateReq.getEndTime(),
+                timeTableDateReq.getStatus(), timeTableDateReq.getOffset()
+        );
+        Pageable pageable = PageRequest.of(timeTableDateReq.getOffset(), 3);
+        return timeTableRepository.getList(timeTableSearchCond, pageable);
+    }
+
 }

--- a/src/main/java/com/festival/old/domain/fleaMarket/repository/FleaMarketRepositoryImpl.java
+++ b/src/main/java/com/festival/old/domain/fleaMarket/repository/FleaMarketRepositoryImpl.java
@@ -1,4 +1,3 @@
-/*
 package com.festival.old.domain.fleaMarket.repository;
 
 import com.festival.old.common.vo.SearchCond;
@@ -13,9 +12,9 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
-import static com.festival.domain.admin.data.entity.QAdmin.*;
-import static com.festival.domain.fleaMarket.data.entity.QFleaMarket.*;
-import static com.festival.domain.fleaMarket.data.entity.QFleaMarketImage.*;
+import static com.festival.old.domain.admin.data.entity.QAdmin.admin;
+import static com.festival.old.domain.fleaMarket.data.entity.QFleaMarket.fleaMarket;
+import static com.festival.old.domain.fleaMarket.data.entity.QFleaMarketImage.fleaMarketImage;
 
 public class FleaMarketRepositoryImpl implements FleaMarketRepositoryCustom {
 
@@ -55,4 +54,3 @@ public class FleaMarketRepositoryImpl implements FleaMarketRepositoryCustom {
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 }
-*/

--- a/src/main/java/com/festival/old/domain/foodTruck/repository/impl/FoodTruckRepositoryCustomImpl.java
+++ b/src/main/java/com/festival/old/domain/foodTruck/repository/impl/FoodTruckRepositoryCustomImpl.java
@@ -1,4 +1,3 @@
-/*
 package com.festival.old.domain.foodTruck.repository.impl;
 
 import com.festival.old.common.vo.SearchCond;
@@ -14,10 +13,9 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
-import static com.festival.domain.admin.data.entity.QAdmin.admin;
-import static com.festival.domain.foodTruck.data.entity.QFoodTruck.foodTruck;
-import static com.festival.domain.foodTruck.data.entity.QFoodTruckImage.foodTruckImage;
-import static com.festival.domain.info.festivalPub.data.entity.pub.QPub.pub;
+import static com.festival.old.domain.admin.data.entity.QAdmin.admin;
+import static com.festival.old.domain.foodTruck.data.entity.QFoodTruck.foodTruck;
+import static com.festival.old.domain.foodTruck.data.entity.QFoodTruckImage.foodTruckImage;
 
 public class FoodTruckRepositoryCustomImpl implements FoodTruckRepositoryCustom {
     private final JPAQueryFactory queryFactory;
@@ -56,4 +54,3 @@ public class FoodTruckRepositoryCustomImpl implements FoodTruckRepositoryCustom 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 }
-*/


### PR DESCRIPTION
# Issue
- #95 

## Issue 내용
- 시간표 도메인의 기본적인 CRUD 기능을 구현했습니다.
- 시간표 도메인의 상태 확인을 위한 TimeTableStatus 클래스를 구현했습니다.
- 시간과 생성, 수정자의 공통 로직을 담당하는 BaseEntity를 구현하였습니다.
<hr>

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**

<br>