### PR TITLE
[#98] 대나무 숲 도메인의 CRUD 기능을 구현한다.

### DIFF
--- a/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
+++ b/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
@@ -1,4 +1,34 @@
 package com.festival.domain.bambooforest.controller;
 
+import com.festival.domain.bambooforest.dto.BamBooForestCreateReq;
+import com.festival.domain.bambooforest.dto.BamBooForestRes;
+import com.festival.domain.bambooforest.service.BamBooForestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/bambooforest")
 public class BambooForestController {
+
+    private final BamBooForestService bambooForestService;
+
+    @PostMapping
+    public ResponseEntity<Long> createBamBooForest(@RequestBody BamBooForestCreateReq bamBooForestCreateReq) {
+        return ResponseEntity.ok().body(bambooForestService.create(bamBooForestCreateReq));
+    }
+
+    @DeleteMapping("/{bamBooForestId}")
+    public ResponseEntity<Void> deleteBamBooForest(@PathVariable Long bamBooForestId) {
+        bambooForestService.delete(bamBooForestId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<BamBooForestRes>> getList(String status, Pageable pageable) {
+        return ResponseEntity.ok().body(bambooForestService.getList(status, pageable));
+    }
 }

--- a/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestCreateReq.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestCreateReq.java
@@ -1,0 +1,21 @@
+package com.festival.domain.bambooforest.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BamBooForestCreateReq {
+
+    private String content;
+    private String contact;
+    private String status;
+
+    @Builder
+    public BamBooForestCreateReq(String content, String contact, String status) {
+        this.content = content;
+        this.contact = contact;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
@@ -1,0 +1,16 @@
+package com.festival.domain.bambooforest.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class BamBooForestRes {
+    private Long id;
+    private String content;
+
+    @QueryProjection
+    public BamBooForestRes(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/festival/domain/bambooforest/dto/BambooForestDto.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BambooForestDto.java
@@ -1,4 +1,0 @@
-package com.festival.domain.bambooforest.dto;
-
-public class BambooForestDto {
-}

--- a/src/main/java/com/festival/domain/bambooforest/model/BamBooForest.java
+++ b/src/main/java/com/festival/domain/bambooforest/model/BamBooForest.java
@@ -1,0 +1,48 @@
+package com.festival.domain.bambooforest.model;
+
+import com.festival.common.base.BaseEntity;
+import com.festival.domain.bambooforest.dto.BamBooForestCreateReq;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BamBooForest extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    private String contact;
+
+    private BamBooForestStatus bamBooForestStatus;
+
+    @Builder
+    private BamBooForest(String content, String contact, BamBooForestStatus bamBooForestStatus) {
+        this.content = content;
+        this.contact = contact;
+        this.bamBooForestStatus = bamBooForestStatus;
+    }
+
+    public static BamBooForest of(BamBooForestCreateReq bambooForestCreateReq) {
+        return BamBooForest.builder()
+                .content(bambooForestCreateReq.getContent())
+                .contact(bambooForestCreateReq.getContact())
+                .bamBooForestStatus(settingStatus(bambooForestCreateReq.getStatus()))
+                .build();
+    }
+
+    public void changeStatus(BamBooForestStatus bamBooForestStatus) {
+        this.bamBooForestStatus = bamBooForestStatus;
+    }
+
+    private static BamBooForestStatus settingStatus(String status) {
+        return BamBooForestStatus.checkStatus(status);
+    }
+}

--- a/src/main/java/com/festival/domain/bambooforest/model/BamBooForestStatus.java
+++ b/src/main/java/com/festival/domain/bambooforest/model/BamBooForestStatus.java
@@ -1,0 +1,24 @@
+package com.festival.domain.bambooforest.model;
+
+import lombok.Getter;
+
+@Getter
+public enum BamBooForestStatus {
+
+    OPERATE("개시"),
+    TERMINATE("삭제");
+
+    private String value;
+
+    BamBooForestStatus(String value) {
+        this.value = value;
+    }
+
+    public static BamBooForestStatus checkStatus(String status) {
+        return switch (status) {
+            case "개시" -> BamBooForestStatus.OPERATE;
+            case "삭제" -> BamBooForestStatus.TERMINATE;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/festival/domain/bambooforest/model/BambooForest.java
+++ b/src/main/java/com/festival/domain/bambooforest/model/BambooForest.java
@@ -1,4 +1,0 @@
-package com.festival.domain.bambooforest.model;
-
-public class BambooForest {
-}

--- a/src/main/java/com/festival/domain/bambooforest/repository/BamBooForestRepository.java
+++ b/src/main/java/com/festival/domain/bambooforest/repository/BamBooForestRepository.java
@@ -1,4 +1,7 @@
 package com.festival.domain.bambooforest.repository;
 
-public interface BamBooForestRepository {
+import com.festival.domain.bambooforest.model.BamBooForest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BamBooForestRepository extends JpaRepository<BamBooForest, Long>, BamBooForestRepositoryCustom {
 }

--- a/src/main/java/com/festival/domain/bambooforest/repository/BamBooForestRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/bambooforest/repository/BamBooForestRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.festival.domain.bambooforest.repository;
+
+import com.festival.domain.bambooforest.dto.BamBooForestRes;
+import com.festival.domain.bambooforest.service.vo.BamBooForestSearchCond;
+import org.springframework.data.domain.Page;
+
+public interface BamBooForestRepositoryCustom {
+    Page<BamBooForestRes> getList(BamBooForestSearchCond bamBooForestSearchCond);
+}

--- a/src/main/java/com/festival/domain/bambooforest/repository/impl/BamBooForestRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/bambooforest/repository/impl/BamBooForestRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.festival.domain.bambooforest.repository.impl;
+
+import com.festival.domain.bambooforest.dto.BamBooForestRes;
+import com.festival.domain.bambooforest.dto.QBamBooForestRes;
+import com.festival.domain.bambooforest.repository.BamBooForestRepositoryCustom;
+import com.festival.domain.bambooforest.service.vo.BamBooForestSearchCond;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.festival.domain.bambooforest.model.QBamBooForest.bamBooForest;
+
+public class BamBooForestRepositoryImpl implements BamBooForestRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public BamBooForestRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<BamBooForestRes> getList(BamBooForestSearchCond bamBooForestSearchCond) {
+        List<BamBooForestRes> result = queryFactory
+                .select(new QBamBooForestRes(
+                        bamBooForest.id,
+                        bamBooForest.content
+                ))
+                .from(bamBooForest)
+                .where(
+                        statusEq(bamBooForestSearchCond.getStatus())
+                )
+                .offset(bamBooForestSearchCond.getPageable().getOffset())
+                .limit(bamBooForestSearchCond.getPageable().getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(bamBooForest.count())
+                .from(bamBooForest)
+                .where(
+                        statusEq(bamBooForestSearchCond.getStatus())
+                );
+
+        return PageableExecutionUtils.getPage(result, bamBooForestSearchCond.getPageable(), countQuery::fetchOne);
+    }
+
+    private static BooleanExpression statusEq(String status) {
+        return bamBooForest.bamBooForestStatus.stringValue().eq(status);
+    }
+}

--- a/src/main/java/com/festival/domain/bambooforest/service/BamBooForestService.java
+++ b/src/main/java/com/festival/domain/bambooforest/service/BamBooForestService.java
@@ -1,4 +1,42 @@
 package com.festival.domain.bambooforest.service;
 
+import com.festival.domain.bambooforest.dto.BamBooForestCreateReq;
+import com.festival.domain.bambooforest.dto.BamBooForestRes;
+import com.festival.domain.bambooforest.model.BamBooForest;
+import com.festival.domain.bambooforest.model.BamBooForestStatus;
+import com.festival.domain.bambooforest.repository.BamBooForestRepository;
+import com.festival.domain.bambooforest.service.vo.BamBooForestSearchCond;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class BamBooForestService {
+
+    private final BamBooForestRepository bamBooForestRepository;
+
+    @Transactional
+    public Long create(BamBooForestCreateReq bambooForestCreateReq) {
+        BamBooForest bamBooForest = BamBooForest.of(bambooForestCreateReq);
+        BamBooForest savedBamBooForest = bamBooForestRepository.save(bamBooForest);
+        return savedBamBooForest.getId();
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        BamBooForest bamBooForest = bamBooForestRepository.findById(id).orElseThrow();
+        bamBooForest.changeStatus(BamBooForestStatus.TERMINATE);
+    }
+
+    public Page<BamBooForestRes> getList(String status, Pageable pageable) {
+        BamBooForestSearchCond bamBooForestSearchCond = BamBooForestSearchCond.builder()
+                .status(status)
+                .pageable(pageable)
+                .build();
+        return bamBooForestRepository.getList(bamBooForestSearchCond);
+    }
 }

--- a/src/main/java/com/festival/domain/bambooforest/service/vo/BamBooForestSearchCond.java
+++ b/src/main/java/com/festival/domain/bambooforest/service/vo/BamBooForestSearchCond.java
@@ -1,0 +1,18 @@
+package com.festival.domain.bambooforest.service.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+public class BamBooForestSearchCond {
+
+    private String status;
+    private Pageable pageable;
+
+    @Builder
+    private BamBooForestSearchCond(String status, Pageable pageable) {
+        this.status = status;
+        this.pageable = pageable;
+    }
+}


### PR DESCRIPTION
# Issue
- #98 

## Issue 내용
- 대나무 숲  도메인의 기본적인 CRUD 기능을 구현했습니다.
- 대나무 숲 도메인의 상태 확인을 위한 BamBooForestStatus 클래스를 구현했습니다.
<hr>

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**

<br>