### PR TITLE
[#102] TimeTable 조회시에 Paging 처리 제거

### DIFF
--- a/src/main/java/com/festival/domain/timetable/dto/TimeTableSearchCond.java
+++ b/src/main/java/com/festival/domain/timetable/dto/TimeTableSearchCond.java
@@ -10,12 +10,10 @@ public class TimeTableSearchCond {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private String status;
-    private int offset;
 
-    public TimeTableSearchCond(LocalDateTime startTime, LocalDateTime endTime, String status, int offset) {
+    public TimeTableSearchCond(LocalDateTime startTime, LocalDateTime endTime, String status) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.status = status;
-        this.offset = offset;
     }
 }

--- a/src/main/java/com/festival/domain/timetable/repository/TimeTableRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/timetable/repository/TimeTableRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface TimeTableRepositoryCustom {
-    List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond, Pageable pageable);
+    List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond);
 }

--- a/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
@@ -23,7 +23,7 @@ public class TimeTableRepositoryImpl implements TimeTableRepositoryCustom {
     }
 
     @Override
-    public List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond, Pageable pageable) {
+    public List<TimeTableRes> getList(TimeTableSearchCond timeTableSearchCond) {
         return queryFactory
                 .select(new QTimeTableRes(
                         timeTable.title
@@ -33,8 +33,6 @@ public class TimeTableRepositoryImpl implements TimeTableRepositoryCustom {
                         isWithinPeriod(timeTableSearchCond.getStartTime(), timeTableSearchCond.getEndTime()),
                         StatusEq(timeTableSearchCond.getStatus())
                 )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
                 .fetch();
     }
 

--- a/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
+++ b/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
@@ -46,10 +46,9 @@ public class TimeTableService {
     public List<TimeTableRes> getList(TimeTableDateReq timeTableDateReq) {
         TimeTableSearchCond timeTableSearchCond = new TimeTableSearchCond(
                 timeTableDateReq.getStartTime(), timeTableDateReq.getEndTime(),
-                timeTableDateReq.getStatus(), timeTableDateReq.getOffset()
+                timeTableDateReq.getStatus()
         );
-        Pageable pageable = PageRequest.of(timeTableDateReq.getOffset(), 3);
-        return timeTableRepository.getList(timeTableSearchCond, pageable);
+        return timeTableRepository.getList(timeTableSearchCond);
     }
 
 }


### PR DESCRIPTION
# Issue
- #102 

## Issue 내용
- 현재 시간표 조회에서는 Paging이 아닌 List로 조회하는 중입니다.
- 따라서 Paging 처리로직을 제거하였습니다.
<hr>

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**

<br>