### PR TITLE
[#107] 멤버 도메인의 기본적인 CRUD로직을 구현한다.

### DIFF
--- a/src/main/java/com/festival/common/security/SecurityConfig.java
+++ b/src/main/java/com/festival/common/security/SecurityConfig.java
@@ -1,4 +1,30 @@
 package com.festival.common.security;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .cors().disable()
+                .authorizeHttpRequests()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .anyRequest().permitAll()
+                .and()
+                .formLogin()
+                .loginPage("/login")
+                .and()
+                .logout()
+                .logoutSuccessUrl("/");
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -1,4 +1,22 @@
 package com.festival.domain.member.controller;
 
+import com.festival.domain.member.dto.MemberReq;
+import com.festival.domain.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/member")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/join")
+    public ResponseEntity<Void> join(@RequestBody @Valid MemberReq memberReq) {
+        memberService.join(memberReq);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -15,7 +15,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public ResponseEntity<Void> join(@RequestBody @Valid MemberReq memberReq) {
+    public ResponseEntity<Void> join(@Valid MemberReq memberReq) {
         memberService.join(memberReq);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/festival/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/festival/domain/member/dto/MemberDto.java
@@ -1,4 +1,0 @@
-package com.festival.domain.member.dto;
-
-public class MemberDto {
-}

--- a/src/main/java/com/festival/domain/member/dto/MemberReq.java
+++ b/src/main/java/com/festival/domain/member/dto/MemberReq.java
@@ -1,0 +1,33 @@
+package com.festival.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberReq {
+
+    @NotBlank(message = "로그인 아이디를 입력 해주세요.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호를 입력 해주세요.")
+    private String password;
+
+    @NotBlank(message = "회원 권한을 선택 해주세요.")
+    private String memberRole;
+
+    @Builder
+    private MemberReq(String loginId, String password, String memberRole) {
+        this.loginId = loginId;
+        this.password = password;
+        this.memberRole = memberRole;
+    }
+
+    public static MemberReq of(String loginId, String password, String memberRole) {
+        return MemberReq.builder()
+                .loginId(loginId)
+                .password(password)
+                .memberRole(memberRole)
+                .build();
+    }
+}

--- a/src/main/java/com/festival/domain/member/model/Member.java
+++ b/src/main/java/com/festival/domain/member/model/Member.java
@@ -1,4 +1,49 @@
 package com.festival.domain.member.model;
 
+import com.festival.domain.member.dto.MemberReq;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String loginId;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
+
+    @Builder
+    private Member(String loginId, String password, MemberRole memberRole) {
+        this.loginId = loginId;
+        this.password = password;
+        this.memberRole = memberRole;
+    }
+
+    public static Member of(MemberReq memberReq, String password) {
+        return Member.builder()
+                .loginId(memberReq.getLoginId())
+                .password(password)
+                .memberRole(settingMemberRole(memberReq.getMemberRole()))
+                .build();
+    }
+
+    public void update(MemberReq memberReq) {
+        this.loginId = memberReq.getLoginId();
+        this.password = memberReq.getPassword();
+        this.memberRole = settingMemberRole(memberReq.getMemberRole());
+    }
+
+    private static MemberRole settingMemberRole(String memberRole) {
+        return MemberRole.checkRole(memberRole);
+    }
 }

--- a/src/main/java/com/festival/domain/member/model/MemberRole.java
+++ b/src/main/java/com/festival/domain/member/model/MemberRole.java
@@ -1,0 +1,21 @@
+package com.festival.domain.member.model;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberRole {
+    ADMIN("ADMIN");
+
+    private String value;
+
+    MemberRole(String value) {
+        this.value = value;
+    }
+
+    public static MemberRole checkRole(String role) {
+        return switch (role) {
+            case "ADMIN" -> ADMIN;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/festival/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/festival/domain/member/repository/MemberRepository.java
@@ -1,4 +1,8 @@
 package com.festival.domain.member.repository;
 
-public class MemberRepository {
+import com.festival.domain.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -1,4 +1,31 @@
 package com.festival.domain.member.service;
 
+import com.festival.domain.member.dto.MemberReq;
+import com.festival.domain.member.model.Member;
+import com.festival.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void join(MemberReq memberReq) {
+        if (isLoginIdSave(memberReq.getLoginId())) {
+            throw new IllegalArgumentException("이미 존재하는 회원입니다.");
+        }
+        Member member = Member.of(memberReq, passwordEncoder.encode(memberReq.getPassword()));
+        Member savedMember = memberRepository.save(member);
+    }
+
+    private boolean isLoginIdSave(String email) {
+        return memberRepository.existsByLoginId(email);
+    }
 }


### PR DESCRIPTION
# Issue
- #107 

## Issue 내용
- 전체적인 Member 도메인의 CRUD 로직을 구현하였습니다.
- 권한을 위한 MemberRole 클래스도 생성했습니다.
- 우선은 세션을 통한 시큐리티 설정만 해두었습니다. 이후에 JWT를 사용하여 인증하는식으로 변경할 예정입니다.

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**