### PR TITLE
[#124] 대나무숲 테스트 케이스 수정

### DIFF
--- a/src/test/java/com/festival/ControllerTestSupport.java
+++ b/src/test/java/com/festival/ControllerTestSupport.java
@@ -11,11 +11,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
-@Import(SecurityConfig.class)
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
-public class ControllerTestSupport {
+public abstract class ControllerTestSupport {
 
     @Autowired
     protected MockMvc mockMvc;


### PR DESCRIPTION
# Issue
- #124  

## Issue 내용
- 테스트 지원 클래스의 타입을 추상화로 변경하였습니다.
- 대나무숲 게시물 삭제 테스트 케이스의 값 확인 로직을 추가하였습니다.
- 대나무숲 게시물 목록 조회 케이스의 사이즈 확인 로직을 추가하였습니다.


**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**
