### PR TITLE
[#129] 엔티티 생성, 수정 시 담당자 업데이트

### DIFF
--- a/src/main/java/com/festival/common/data/Data.java
+++ b/src/main/java/com/festival/common/data/Data.java
@@ -1,0 +1,29 @@
+package com.festival.common.data;
+
+import com.festival.domain.member.dto.MemberJoinReq;
+import com.festival.domain.member.service.MemberService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile({"dev", "test"})
+@Configuration
+@Transactional
+public class Data {
+    private boolean initDataDone = false;
+
+    @Bean
+    CommandLineRunner initData(
+            MemberService memberService
+    ) {
+        return args -> {
+
+            if (initDataDone) return;
+
+            initDataDone = true;
+            memberService.join(MemberJoinReq.of("user", "1234", "ADMIN"));
+        };
+    }
+}

--- a/src/main/java/com/festival/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/festival/common/security/JwtTokenProvider.java
@@ -44,9 +44,9 @@ public class JwtTokenProvider {
         Date refreshTokenTime = new Date(now.getTime() + 60 * 60 * 1000L);
 
         String accessToken = Jwts.builder()
-                .claim("roles", roles)
-                .setSubject(authentication.getName())
-                .setExpiration(initializationAccessTime)
+                .claim("roles", roles) // 권한정보
+                .setSubject(authentication.getName()) // 아이디
+                .setExpiration(initializationAccessTime) // 만료기간
                 .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
 

--- a/src/main/java/com/festival/common/util/AuditingConfig.java
+++ b/src/main/java/com/festival/common/util/AuditingConfig.java
@@ -1,9 +1,24 @@
 package com.festival.common.util;
 
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
 
 @Configuration
 @EnableJpaAuditing
 public class AuditingConfig {
+
+    /**
+     * @Description
+     * 엔티티를 생성, 수정한 사람의 정보를 세션에서 가져와 채워줍니다.
+      */
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
 }


### PR DESCRIPTION
# Issue
- #124  

## Issue 내용
- 로그인을 위한 더미 데이터를 추가했습니다. 추후에 .sql 파일로 대체하면 좋을 것 같습니다.
- @CreatedBy와 @UpdatedBy가 동작하지 않는 것을 확인하고 수정했습니다.
-> AuditingConfig에서 AuditorAware<String>을 빈으로 등록해주었습니다.

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**
