### PR TITLE
[#131] 대나무숲 서비스 단위 테스트 작성

### DIFF
--- a/src/test/java/com/festival/domain/bambooforest/fixture/BamBooForestFixture.java
+++ b/src/test/java/com/festival/domain/bambooforest/fixture/BamBooForestFixture.java
@@ -1,0 +1,19 @@
+package com.festival.domain.bambooforest.fixture;
+
+
+import com.festival.domain.bambooforest.model.BamBooForest;
+import com.festival.domain.bambooforest.model.BamBooForestStatus;
+import com.festival.domain.booth.model.Booth;
+import com.festival.domain.booth.model.BoothType;
+
+import static com.festival.domain.booth.model.BoothStatus.OPERATE;
+
+public class BamBooForestFixture {
+
+    public static BamBooForest bamBooForest = BamBooForest.builder()
+            .content("대나무 숲 글 내용")
+            .contact("010-1234-5678")
+            .bamBooForestStatus(BamBooForestStatus.OPERATE)
+            .build();
+}
+

--- a/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
+++ b/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
@@ -1,0 +1,120 @@
+package com.festival.domain.bambooforest.service;
+
+import com.festival.common.exception.custom_exception.NotFoundException;
+import com.festival.domain.bambooforest.dto.BamBooForestCreateReq;
+import com.festival.domain.bambooforest.fixture.BamBooForestFixture;
+import com.festival.domain.bambooforest.model.BamBooForest;
+import com.festival.domain.bambooforest.repository.BamBooForestRepository;
+import com.festival.domain.bambooforest.service.vo.BamBooForestSearchCond;
+import com.festival.domain.booth.controller.dto.BoothListReq;
+import com.festival.domain.booth.controller.dto.BoothReq;
+import com.festival.domain.booth.controller.dto.BoothRes;
+import com.festival.domain.booth.fixture.BoothFixture;
+import com.festival.domain.booth.model.Booth;
+import com.festival.domain.booth.service.vo.BoothListSearchCond;
+import com.festival.domain.image.fixture.ImageFixture;
+import com.festival.domain.member.fixture.MemberFixture;
+import com.festival.domain.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.festival.common.exception.ErrorCode.NOT_FOUND_BAMBOO;
+import static com.festival.domain.bambooforest.fixture.BamBooForestFixture.bamBooForest;
+import static com.festival.domain.util.TestImageUtils.generateMockImageFile;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class BamBooForestServiceTest {
+
+    @InjectMocks
+    private BamBooForestService bamBooForestService;
+    @Mock
+    private BamBooForestRepository bamBooForestRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+
+    @DisplayName("대나무 숲을 생성한 후 boothId를 반환한다.")
+    @Test
+    void createBamBooForest() {
+
+        //given
+        BamBooForestCreateReq bambooCreateReq = BamBooForestCreateReq.builder()
+                .content("대나무 숲 글 내용")
+                .status("OPERATE")
+                .contact("010-1234-5678")
+                .build();
+
+        BamBooForest bamBooForest = BamBooForestFixture.bamBooForest;
+        ReflectionTestUtils.setField(bamBooForest, "id",1L);
+
+        given(bamBooForestRepository.save(any(BamBooForest.class)))
+                .willReturn(bamBooForest);
+
+        //when
+        Long bambooForestId = bamBooForestService.create(bambooCreateReq);
+
+        //then
+        Assertions.assertThat(bambooForestId).isEqualTo(1L);
+    }
+    @DisplayName("대나무 숲을 삭제하면 오류가 없을 시 정상흐름.")
+    @Test
+    void deleteBamBooForest1() {
+
+        //given
+        given(bamBooForestRepository.findById(1L))
+                .willReturn(Optional.of(bamBooForest));
+        given(memberRepository.findByLoginId("user"))
+                .willReturn(Optional.of(MemberFixture.member));
+
+        //when
+        bamBooForestService.delete(1L, "user");
+
+
+        //then
+    }
+
+    @DisplayName("존재하지 않는 대나무 숲을 삭제하면 NotFoundException를 반환한다.")
+    @Test
+    void deleteBamBooForest2() {
+
+        //given
+        given(bamBooForestRepository.findById(1L))
+                .willThrow(new NotFoundException(NOT_FOUND_BAMBOO));
+
+
+        //when & then
+        assertThatThrownBy(() -> bamBooForestService.delete(1L, "username"))
+                .isInstanceOf(NotFoundException.class)
+                .extracting("errorCode")
+                .isEqualTo(NOT_FOUND_BAMBOO);
+    }
+/*
+
+    @DisplayName("조건에 맞는 대나무숲 리스트 반환한다.")
+    @Test
+    void getBamBooList(){
+        //given
+        //when
+        //then
+    }
+*/
+
+
+}

--- a/src/test/java/com/festival/domain/member/fixture/MemberFixture.java
+++ b/src/test/java/com/festival/domain/member/fixture/MemberFixture.java
@@ -1,0 +1,14 @@
+package com.festival.domain.member.fixture;
+
+import com.festival.domain.member.model.Member;
+import com.festival.domain.member.model.MemberRole;
+
+public class MemberFixture {
+
+    public static Member member = Member.builder()
+            .loginId("user")
+            .password("1234")
+            .memberRole(MemberRole.ADMIN)
+            .build();
+
+}


### PR DESCRIPTION
# Issue
- #131 

## Issue 내용
- 대나무숲 서비스 계층의 단위 테스트를 작성했습니다.
- 생성, 삭제에 대한 테스트를 작성했습니다.
- 리스트 조회는 회의 이후 작성하겠습니다.
- 권한 검사를 위한 MemberFixture를 따로 생성해두었습니다.

**코드의 개선점이나 수정이 필요한 부분에 대한 의견을 주시면 감사하겠습니다.**
