### PR TITLE
[#124, #128] 대나무숲, 안내사항 통합테스트 케이스 추가

### DIFF
--- a/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
+++ b/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
@@ -5,17 +5,8 @@ import com.festival.domain.bambooforest.dto.BamBooForestCreateReq;
 import com.festival.domain.bambooforest.fixture.BamBooForestFixture;
 import com.festival.domain.bambooforest.model.BamBooForest;
 import com.festival.domain.bambooforest.repository.BamBooForestRepository;
-import com.festival.domain.bambooforest.service.vo.BamBooForestSearchCond;
-import com.festival.domain.booth.controller.dto.BoothListReq;
-import com.festival.domain.booth.controller.dto.BoothReq;
-import com.festival.domain.booth.controller.dto.BoothRes;
-import com.festival.domain.booth.fixture.BoothFixture;
-import com.festival.domain.booth.model.Booth;
-import com.festival.domain.booth.service.vo.BoothListSearchCond;
-import com.festival.domain.image.fixture.ImageFixture;
 import com.festival.domain.member.fixture.MemberFixture;
 import com.festival.domain.member.repository.MemberRepository;
-import com.festival.domain.member.service.MemberService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,20 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 
 import static com.festival.common.exception.ErrorCode.NOT_FOUND_BAMBOO;
 import static com.festival.domain.bambooforest.fixture.BamBooForestFixture.bamBooForest;
-import static com.festival.domain.util.TestImageUtils.generateMockImageFile;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -50,7 +34,6 @@ class BamBooForestServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
-
     @DisplayName("대나무 숲을 생성한 후 boothId를 반환한다.")
     @Test
     void createBamBooForest() {
@@ -63,7 +46,7 @@ class BamBooForestServiceTest {
                 .build();
 
         BamBooForest bamBooForest = BamBooForestFixture.bamBooForest;
-        ReflectionTestUtils.setField(bamBooForest, "id",1L);
+        ReflectionTestUtils.setField(bamBooForest, "id", 1L);
 
         given(bamBooForestRepository.save(any(BamBooForest.class)))
                 .willReturn(bamBooForest);

--- a/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
+++ b/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
@@ -1,6 +1,5 @@
 package com.festival.domain.booth.service;
 
-import com.festival.common.exception.custom_exception.NotFoundException;
 import com.festival.domain.booth.controller.dto.BoothListReq;
 import com.festival.domain.booth.controller.dto.BoothReq;
 import com.festival.domain.booth.controller.dto.BoothRes;
@@ -25,13 +24,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static com.festival.common.exception.ErrorCode.NOT_FOUND_BOOTH;
 import static com.festival.domain.util.TestImageUtils.generateMockImageFile;
-import static io.jsonwebtoken.lang.Assert.isInstanceOf;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-
 
 @ExtendWith(MockitoExtension.class)
 class BoothServiceTest {


### PR DESCRIPTION
# Issue
- #124
- #128 

# Issue 내용
- 권한 분리, 상태값 로직 변경 및 이동에 따른 예외사항 테스트케이스를 추가하였습니다.