### PR TITLE
[#145] 축제부스 통합 테스트 로직을 작성한다.

### DIFF
--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -7,19 +7,13 @@ import com.festival.domain.booth.controller.dto.BoothRes;
 import com.festival.domain.booth.service.BoothService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-
-@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v2/booth")
@@ -30,7 +24,7 @@ public class BoothController {
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PostMapping
-    public ResponseEntity<Long> create(@Valid BoothReq boothReq) throws Exception {
+    public ResponseEntity<Long> createBooth(@Valid BoothReq boothReq) throws Exception {
         if (!validationUtils.isBoothValid(boothReq)) {
             throw new Exception();
         }
@@ -39,7 +33,7 @@ public class BoothController {
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PutMapping("/{boothId}")
-    public ResponseEntity<Long> update(@Valid BoothReq boothReq, @PathVariable("boothId") Long id) throws Exception {
+    public ResponseEntity<Long> updateBooth(@Valid BoothReq boothReq, @PathVariable("boothId") Long id) throws Exception {
         if (!validationUtils.isBoothValid(boothReq)) {
             throw new Exception();
         }
@@ -48,7 +42,7 @@ public class BoothController {
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @DeleteMapping("/{boothId}")
-    public ResponseEntity<Void> delete(@PathVariable("boothId") Long id) {
+    public ResponseEntity<Void> deleteBooth(@PathVariable("boothId") Long id) {
         boothService.deleteBooth(id);
         return ResponseEntity.ok().build();
     }
@@ -61,7 +55,7 @@ public class BoothController {
 
     @PreAuthorize("permitAll()")
     @GetMapping("/list")
-    public ResponseEntity<List<BoothRes>> getlist(@Valid BoothListReq boothListReq, Pageable pageable) {
+    public ResponseEntity<List<BoothRes>> getBoothList(@Valid BoothListReq boothListReq, Pageable pageable) {
         return ResponseEntity.ok().body(boothService.getBoothList(boothListReq, pageable));
     }
 }

--- a/src/main/java/com/festival/domain/booth/controller/dto/BoothReq.java
+++ b/src/main/java/com/festival/domain/booth/controller/dto/BoothReq.java
@@ -2,16 +2,19 @@ package com.festival.domain.booth.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class BoothReq {
-
 
     @NotBlank(message = "제목을 입력해주세요")
     private String title;
@@ -28,15 +31,16 @@ public class BoothReq {
     @NotNull(message = "경도를 입력 해주세요.")
     private float longitude;
 
-    @NotNull(message = "상태를 선택 해주세요.")
-    private String status;
-
     @NotNull(message = "타입을 선택 해주세요.")
     private String type;
+
+    @NotNull(message = "상태를 선택 해주세요.")
+    private String status;
 
     @NotNull(message = "썸네일 이미지를 선택해주세요")
     private MultipartFile mainFile;
 
     @NotNull(message = "서브 이미지를 선택해주세요")
     private List<MultipartFile> subFiles;
+
 }

--- a/src/main/java/com/festival/domain/booth/model/Booth.java
+++ b/src/main/java/com/festival/domain/booth/model/Booth.java
@@ -32,7 +32,7 @@ public class Booth extends BaseEntity {
     @Column(nullable = false)
     private float latitude;
 
-    @Column(nullable = false) // 경도
+    @Column(nullable = false)
     private float longitude;
 
     @Column(nullable = false)

--- a/src/main/java/com/festival/domain/booth/model/BoothType.java
+++ b/src/main/java/com/festival/domain/booth/model/BoothType.java
@@ -1,31 +1,25 @@
 package com.festival.domain.booth.model;
 
+import lombok.Getter;
+
+@Getter
 public enum BoothType {
-    FOOD_TRUCK("푸드트럭"),
-    FLEA_MARKET("플리마켓"),
-    PUB("주점");
+    FOOD_TRUCK("FOOD_TRUCK"),
+    FLEA_MARKET("FLEA_MARKET"),
+    PUB("PUB");
 
     private final String value;
 
     BoothType(String value){
         this.value = value;
     }
-    public static BoothType handleType(String type)
-    {
-        switch (type) {
-            case "FOOD_TRUCK":
-                return BoothType.FOOD_TRUCK;
-            case "FLEA_MARKET":
-                return BoothType.FLEA_MARKET;
-            case "PUB":
-                return BoothType.PUB;
-            default:
-                return null;
-        }
-    }
 
-    public String getValue(){
-        return value;
+    public static BoothType handleType(String type) {
+        return switch (type) {
+            case "FOOD_TRUCK" -> BoothType.FOOD_TRUCK;
+            case "FLEA_MARKET" -> BoothType.FLEA_MARKET;
+            case "PUB" -> BoothType.PUB;
+            default -> null;
+        };
     }
-
 }

--- a/src/main/java/com/festival/domain/guide/dto/GuideReq.java
+++ b/src/main/java/com/festival/domain/guide/dto/GuideReq.java
@@ -26,10 +26,10 @@ public class GuideReq {
     @NotNull(message = "상태값을 입력해주세요")
     private String status;
 
-//    @NotNull(message = "썸네일 이미지를 선택해주세요")
+    @NotNull(message = "썸네일 이미지를 선택해주세요")
     private MultipartFile mainFile;
 
-//    @NotNull(message = "서브 이미지를 선택해주세요")
+    @NotNull(message = "서브 이미지를 선택해주세요")
     private List<MultipartFile> subFiles;
 
     @Builder

--- a/src/test/java/com/festival/domain/bambooforest/controller/BambooForestControllerTest.java
+++ b/src/test/java/com/festival/domain/bambooforest/controller/BambooForestControllerTest.java
@@ -32,9 +32,6 @@ class BambooForestControllerTest extends ControllerTestSupport {
     @Autowired
     private BamBooForestRepository bamBooForestRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
-
     private Member member;
 
     private Member differentMember;

--- a/src/test/java/com/festival/domain/booth/controller/BoothControllerTest.java
+++ b/src/test/java/com/festival/domain/booth/controller/BoothControllerTest.java
@@ -1,0 +1,467 @@
+package com.festival.domain.booth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festival.common.base.OperateStatus;
+import com.festival.common.exception.ErrorCode;
+import com.festival.common.exception.custom_exception.NotFoundException;
+import com.festival.domain.booth.controller.dto.BoothReq;
+import com.festival.domain.booth.controller.dto.BoothRes;
+import com.festival.domain.booth.model.Booth;
+import com.festival.domain.booth.model.BoothType;
+import com.festival.domain.booth.repository.BoothRepository;
+import com.festival.domain.guide.dto.GuideRes;
+import com.festival.domain.image.model.Image;
+import com.festival.domain.member.model.Member;
+import com.festival.domain.util.ControllerTestSupport;
+import com.festival.domain.util.TestImageUtils;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.festival.domain.member.model.MemberRole.ADMIN;
+import static com.festival.domain.member.model.MemberRole.MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BoothControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private BoothRepository boothRepository;
+
+    private Member member;
+
+    private Member differentMember;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .username("testUser")
+                .password("12345")
+                .memberRole(ADMIN)
+                .build();
+        memberRepository.saveAndFlush(member);
+
+        differentMember = Member.builder()
+                .username("differentUser")
+                .password("12345")
+                .memberRole(MANAGER)
+                .build();
+        memberRepository.saveAndFlush(differentMember);
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("축제부스 게시물을 생성한다.")
+    @Test
+    void createBooth() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .mainFile(mainFile)
+                .build();
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        multipart("/api/v2/booth")
+                                .file(mainFile)
+                                .file(subFiles.get(0))
+                                .file(subFiles.get(1))
+                                .file(subFiles.get(2))
+                                .param("title", boothReq.getTitle())
+                                .param("subTitle", boothReq.getSubTitle())
+                                .param("content", boothReq.getContent())
+                                .param("latitude", String.valueOf(boothReq.getLatitude()))
+                                .param("longitude", String.valueOf(boothReq.getLongitude()))
+                                .param("status", boothReq.getStatus())
+                                .param("type", boothReq.getType())
+                                .contentType(MULTIPART_FORM_DATA)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        Long boothId = Long.parseLong(mvcResult.getResponse().getContentAsString());
+        Booth booth = boothRepository.findById(boothId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_BOOTH));
+        assertThat(booth).isNotNull()
+                .extracting("title", "content", "type", "status")
+                .containsExactly(boothReq.getTitle(), boothReq.getContent(), BoothType.FOOD_TRUCK, OperateStatus.OPERATE);
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("축제부스 게시물을 수정한다.")
+    @Test
+    void updateBooth() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .mainFile(mainFile)
+                .build();
+        Booth booth = Booth.of(boothReq);
+        booth.connectMember(member);
+        Booth savedBooth = boothRepository.saveAndFlush(booth);
+
+        //when
+        MockHttpServletRequestBuilder builder = multipart("/api/v2/booth/" + savedBooth.getId())
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("subTitle", "updateSubTitle")
+                .param("content", "updateContent")
+                .param("latitude", String.valueOf(50.0f))
+                .param("longitude", String.valueOf(50.0f))
+                .param("type", "FOOD_TRUCK")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        MvcResult mvcResult = mockMvc.perform(builder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(savedBooth.getId().toString()))
+                .andReturn();
+
+        //then
+        Long boothId = Long.parseLong(mvcResult.getResponse().getContentAsString());
+        Booth findBooth = boothRepository.findById(boothId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_BOOTH));
+        assertThat(findBooth).isNotNull()
+                .extracting("title", "content", "type", "status")
+                .containsExactly("updateTitle", "updateContent", BoothType.FOOD_TRUCK, OperateStatus.OPERATE);
+    }
+
+    @WithMockUser(username = "differentUser", roles = "MANAGER")
+    @DisplayName("축제부스 게시물을 수정할 때, 다른 사용자는 수정할 권한이 없다.")
+    @Test
+    void updateBoothNotMine() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .mainFile(mainFile)
+                .build();
+        Booth booth = Booth.of(boothReq);
+        booth.connectMember(member);
+        Booth savedBooth = boothRepository.saveAndFlush(booth);
+
+        //when //then
+        MockHttpServletRequestBuilder builder = multipart("/api/v2/booth/" + savedBooth.getId())
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("subTitle", "updateSubTitle")
+                .param("content", "updateContent")
+                .param("latitude", String.valueOf(50.0f))
+                .param("longitude", String.valueOf(50.0f))
+                .param("type", "FLEA_MARKET")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        mockMvc.perform(builder)
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("축제부스 게시물을 수정할 때, 존재하지 않는 게시물은 수정할 수 없다.")
+    @Test
+    void updateBoothNotFound() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        //when //then
+        MockHttpServletRequestBuilder builder = multipart("/api/v2/booth/1")
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("subTitle", "updateSubTitle")
+                .param("content", "updateContent")
+                .param("latitude", String.valueOf(50.0f))
+                .param("longitude", String.valueOf(50.0f))
+                .param("type", "FLEA_MARKET")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        mockMvc.perform(builder)
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("축제부스 게시물을 하나 삭제한다.")
+    @Test
+    void deleteBooth() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .mainFile(mainFile)
+                .build();
+        Booth booth = Booth.of(boothReq);
+        booth.connectMember(member);
+        Booth savedBooth = boothRepository.saveAndFlush(booth);
+
+        //when
+        mockMvc.perform(
+                        delete("/api/v2/booth/" + savedBooth.getId())
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        Booth findBooth = boothRepository.findById(savedBooth.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_BOOTH));
+        assertThat(findBooth.getStatus()).isEqualTo(OperateStatus.TERMINATE);
+    }
+
+    @WithMockUser(username = "differentUser", roles = "MANAGER")
+    @DisplayName("삭제권한이 없는 게시물은 삭제할 수 없다.")
+    @Test
+    void deleteBoothNotMine() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .mainFile(mainFile)
+                .build();
+        Booth booth = Booth.of(boothReq);
+        booth.connectMember(member);
+        Booth savedBooth = boothRepository.saveAndFlush(booth);
+
+        //when //then
+        mockMvc.perform(
+                        delete("/api/v2/booth/" + savedBooth.getId())
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("존재하지 않는 축제부스 게시물은 삭제할 수 없다.")
+    @Test
+    void deleteBoothNotFound() throws Exception {
+        //when //then
+        mockMvc.perform(
+                        delete("/api/v2/booth/1")
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("축제부스 게시물 중에 하나를 조회한다.")
+    @Test
+    void getBooth() throws Exception {
+        //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle")
+                .subTitle("testSubTitle")
+                .content("testContent")
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .build();
+        Booth booth = Booth.of(boothReq);
+        Image image = Image.builder()
+                .mainFilePath(mainFile.getName())
+                .subFilePaths(subFiles.stream().map(MockMultipartFile::getName).toList())
+                .build();
+        booth.connectMember(member);
+        booth.setImage(image);
+        Booth savedBooth = boothRepository.saveAndFlush(booth);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/v2/booth/" + savedBooth.getId())
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        BoothRes findBooth = new ObjectMapper().readValue(mvcResult.getResponse().getContentAsString(), BoothRes.class);
+        assertThat(findBooth).isNotNull()
+                .extracting("title", "content", "type", "status")
+                .containsExactly(boothReq.getTitle(), boothReq.getContent(), "FOOD_TRUCK", "OPERATE");
+    }
+
+    @DisplayName("존재하지 않는 축제부스 게시물은 조회할 수 없다.")
+    @Test
+    void getBoothNotFound() throws Exception {
+        //when //then
+        mockMvc.perform(
+                        get("/api/v2/booth/1")
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("축제부스 게시물을 여러개 조회한다.")
+    @Test
+    void getBoothList() throws Exception {
+        //given
+        createBoothEntity(1);
+        createBoothEntity(2);
+        createBoothEntity(3);
+        createBoothEntity(4);
+        createBoothEntity(5);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/v2/booth/list")
+                                .param("status", "OPERATE")
+                                .param("type", "FOOD_TRUCK")
+                                .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String content = mvcResult.getResponse().getContentAsString();
+        List<BoothRes> boothResList = objectMapper.readValue(content, objectMapper.getTypeFactory().constructCollectionType(List.class, BoothRes.class));
+        assertThat(boothResList).hasSize(5)
+                .extracting("title", "content", "type", "status")
+                .containsExactlyInAnyOrder(
+                        tuple("testTitle1", "testContent1", "FOOD_TRUCK", "OPERATE"),
+                        tuple("testTitle2", "testContent2", "FOOD_TRUCK", "OPERATE"),
+                        tuple("testTitle3", "testContent3", "FOOD_TRUCK", "OPERATE"),
+                        tuple("testTitle4", "testContent4", "FOOD_TRUCK", "OPERATE"),
+                        tuple("testTitle5", "testContent5", "FOOD_TRUCK", "OPERATE")
+                );
+    }
+
+    private Booth createBoothEntity(int count) throws IOException {
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
+        BoothReq boothReq = BoothReq.builder()
+                .title("testTitle" + count)
+                .subTitle("testSubTitle" + count)
+                .content("testContent" + count)
+                .latitude(50.0f)
+                .longitude(50.0f)
+                .type("FOOD_TRUCK")
+                .status("OPERATE")
+                .build();
+        Booth booth = Booth.of(boothReq);
+        Image image = Image.builder()
+                .mainFilePath(mainFile.getName())
+                .subFilePaths(subFiles.stream().map(MockMultipartFile::getName).toList())
+                .build();
+        booth.connectMember(member);
+        booth.setImage(image);
+        return boothRepository.saveAndFlush(booth);
+    }
+}

--- a/src/test/java/com/festival/domain/guide/controller/GuideControllerTest.java
+++ b/src/test/java/com/festival/domain/guide/controller/GuideControllerTest.java
@@ -8,7 +8,6 @@ import com.festival.domain.guide.repository.GuideRepository;
 import com.festival.domain.image.fixture.ImageFixture;
 import com.festival.domain.image.model.Image;
 import com.festival.domain.member.model.Member;
-import com.festival.domain.member.repository.MemberRepository;
 import com.festival.domain.util.ControllerTestSupport;
 import com.festival.domain.util.TestImageUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
@@ -39,9 +40,6 @@ class GuideControllerTest extends ControllerTestSupport {
 
     @Autowired
     private GuideRepository guideRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     private Member member;
 
@@ -114,6 +112,13 @@ class GuideControllerTest extends ControllerTestSupport {
     @Test
     void updateGuide() throws Exception {
         //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
         GuideReq guideReq = GuideReq.builder()
                 .title("title")
                 .content("content")
@@ -125,14 +130,22 @@ class GuideControllerTest extends ControllerTestSupport {
         Guide savedGuide = guideRepository.saveAndFlush(guide);
 
         //when
-        mockMvc.perform(
-                        put("/api/v2/guide/" + savedGuide.getId())
-                                .param("title", "updateTitle")
-                                .param("content", "updateContent")
-                                .param("type", "NOTICE")
-                                .param("status", "OPERATE")
-                                .contentType(MULTIPART_FORM_DATA)
-                )
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart("/api/v2/guide/" + savedGuide.getId())
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("content", "updateContent")
+                .param("type", "NOTICE")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        mockMvc.perform(builder)
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string(savedGuide.getId().toString()));
@@ -148,15 +161,30 @@ class GuideControllerTest extends ControllerTestSupport {
     @DisplayName("게시물을 수정 시도할 때, 안내사항 게시물이 존재하지 않으면 NotFoundException을 반환한다.")
     @Test
     void updateGuideNotFound() throws Exception {
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
         //when //then
-        mockMvc.perform(
-                        put("/api/v2/guide/1")
-                                .param("title", "updateTitle")
-                                .param("content", "updateContent")
-                                .param("type", "NOTICE")
-                                .param("status", "OPERATE")
-                                .contentType(MULTIPART_FORM_DATA)
-                )
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart("/api/v2/guide/1")
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("content", "updateContent")
+                .param("type", "NOTICE")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        mockMvc.perform(builder)
                 .andDo(print())
                 .andExpect(status().isNotFound());
     }
@@ -166,22 +194,36 @@ class GuideControllerTest extends ControllerTestSupport {
     @Test
     void updateGuideNotMine() throws Exception {
         //given
+        MockMultipartFile mainFile = TestImageUtils.generateMockImageFile("mainFile");
+        List<MockMultipartFile> subFiles = List.of(
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles"),
+                TestImageUtils.generateMockImageFile("subFiles")
+        );
+
         Guide guide = createGuideEntity("title", "content", "QNA", "OPERATE");
         guide.connectMember(member);
         Guide savedGuide = guideRepository.saveAndFlush(guide);
 
         //when //then
-        mockMvc.perform(
-                        put("/api/v2/guide/" + savedGuide.getId())
-                                .param("title", "updateTitle")
-                                .param("content", "updateContent")
-                                .param("type", "NOTICE")
-                                .param("status", "OPERATE")
-                                .contentType(MULTIPART_FORM_DATA)
-                )
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart("/api/v2/guide/" + savedGuide.getId())
+                .file(mainFile)
+                .file(subFiles.get(0))
+                .file(subFiles.get(1))
+                .file(subFiles.get(2))
+                .param("title", "updateTitle")
+                .param("content", "updateContent")
+                .param("type", "NOTICE")
+                .param("status", "OPERATE")
+                .contentType(MULTIPART_FORM_DATA)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                });
+
+        mockMvc.perform(builder)
                 .andDo(print())
                 .andExpect(status().isForbidden());
-
     }
 
     @WithMockUser(username = "testUser", roles = "ADMIN")

--- a/src/test/java/com/festival/domain/util/ControllerTestSupport.java
+++ b/src/test/java/com/festival/domain/util/ControllerTestSupport.java
@@ -1,6 +1,7 @@
 package com.festival.domain.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.festival.domain.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,4 +21,6 @@ public abstract class ControllerTestSupport {
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @Autowired
+    protected MemberRepository memberRepository;
 }


### PR DESCRIPTION
# Issue
- #145 

## Issue 내용
- 축제부스 통합 테스트 로직을 구현하였습니다.
- 테스트시에 MockMultipartFile이 Put에서는 입력이 되지 않았지만,
- 커스텀 Request타입을 만들어서 put 헤더에서도 file을 보낼 수 있도록 하였습니다.
<img width="418" alt="image" src="https://github.com/miIlicon/WithFestival-BackEnd/assets/26915908/dd6e7c0f-0bec-4ac0-a4af-8c1184cb59a0">

**PR에서는 축제부스 도메인에 대한 통합 테스트 로직과 리팩토링 사항이 있습니다. 확인하시고 리뷰해주시면 감사하겠습니다.**
