### PR TITLE
[#153] 시간표 도메인에 대한 통합 테스트 로직을 구현한다.

### DIFF
--- a/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
+++ b/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
@@ -27,7 +27,7 @@ public class TimeTableController {
         if (!validationUtils.isTimeTableValid(timeTableReq)) {
             throw new Exception();
         }
-        return ResponseEntity.ok().body(timeTableService.create(timeTableReq));
+        return ResponseEntity.ok().body(timeTableService.createTimeTable(timeTableReq));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
@@ -37,19 +37,19 @@ public class TimeTableController {
         if (!validationUtils.isTimeTableValid(timeTableReq)) {
             throw new Exception();
         }
-        return ResponseEntity.ok().body(timeTableService.update(timeTableId, timeTableReq));
+        return ResponseEntity.ok().body(timeTableService.updateTimeTable(timeTableId, timeTableReq));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @DeleteMapping("/{timeTableId}")
     public ResponseEntity<Void> deleteTimeTable(@PathVariable Long timeTableId) {
-        timeTableService.delete(timeTableId);
+        timeTableService.deleteTimeTable(timeTableId);
         return ResponseEntity.ok().build();
     }
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
-    @GetMapping
+    @GetMapping("/list")
     public ResponseEntity<List<TimeTableRes>> getTimeTables(@Valid TimeTableDateReq timeTableDateReq) {
-        return ResponseEntity.ok().body(timeTableService.getList(timeTableDateReq));
+        return ResponseEntity.ok().body(timeTableService.getTimeTableList(timeTableDateReq));
     }
 }

--- a/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
@@ -39,8 +39,8 @@ public class TimeTableRepositoryImpl implements TimeTableRepositoryCustom {
         if (startTime == null || endTime == null) {
             return null;
         }
-        return timeTable.startTime.after(startTime)
-                .and(timeTable.endTime.before(endTime));
+        return timeTable.startTime.goe(startTime)
+                .and(timeTable.endTime.loe(endTime));
     }
 
     private static BooleanExpression StatusEq(String status) {

--- a/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
+++ b/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
@@ -7,8 +7,8 @@ import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
 import com.festival.common.util.SecurityUtils;
 import com.festival.domain.member.service.MemberService;
-import com.festival.domain.timetable.dto.TimeTableReq;
 import com.festival.domain.timetable.dto.TimeTableDateReq;
+import com.festival.domain.timetable.dto.TimeTableReq;
 import com.festival.domain.timetable.dto.TimeTableRes;
 import com.festival.domain.timetable.dto.TimeTableSearchCond;
 import com.festival.domain.timetable.model.TimeTable;
@@ -33,7 +33,7 @@ public class TimeTableService {
     private final MemberService memberService;
 
     @Transactional
-    public Long create(TimeTableReq timeTableReq) {
+    public Long createTimeTable(TimeTableReq timeTableReq) {
         TimeTable timeTable = TimeTable.of(timeTableReq);
         timeTable.connectMember(memberService.getAuthenticationMember());
         TimeTable savedTimeTable = timeTableRepository.save(timeTable);
@@ -41,7 +41,7 @@ public class TimeTableService {
     }
 
     @Transactional
-    public Long update(Long timeTableId, TimeTableReq timeTableReq) {
+    public Long updateTimeTable(Long timeTableId, TimeTableReq timeTableReq) {
         TimeTable timeTable = checkingDeletedStatus(timeTableRepository.findById(timeTableId));
 
         if(!SecurityUtils.checkingAdminRole(memberService.getAuthenticationMember().getMemberRoles())) {
@@ -52,7 +52,7 @@ public class TimeTableService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void deleteTimeTable(Long id) {
         TimeTable timeTable = checkingDeletedStatus(timeTableRepository.findById(id));
         if(!SecurityUtils.checkingAdminRole(memberService.getAuthenticationMember().getMemberRoles())) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN_DELETE);
@@ -60,13 +60,14 @@ public class TimeTableService {
         timeTable.changeStatus(OperateStatus.TERMINATE);
     }
 
-    public List<TimeTableRes> getList(TimeTableDateReq timeTableDateReq) {
+    public List<TimeTableRes> getTimeTableList(TimeTableDateReq timeTableDateReq) {
         TimeTableSearchCond timeTableSearchCond = new TimeTableSearchCond(
                 timeTableDateReq.getStartTime(), timeTableDateReq.getEndTime(),
                 timeTableDateReq.getStatus()
         );
         return timeTableRepository.getList(timeTableSearchCond);
     }
+
     private TimeTable checkingDeletedStatus(Optional<TimeTable> timeTable) {
         if (timeTable.isEmpty()) {
             throw new NotFoundException(NOT_FOUND_TIMETABLE);
@@ -77,4 +78,5 @@ public class TimeTableService {
         }
         return timeTable.get();
     }
+
 }

--- a/src/test/java/com/festival/domain/timetable/controller/TimeTableControllerTest.java
+++ b/src/test/java/com/festival/domain/timetable/controller/TimeTableControllerTest.java
@@ -1,0 +1,277 @@
+package com.festival.domain.timetable.controller;
+
+import com.festival.common.base.OperateStatus;
+import com.festival.common.exception.ErrorCode;
+import com.festival.common.exception.custom_exception.NotFoundException;
+import com.festival.domain.member.model.Member;
+import com.festival.domain.program.dto.ProgramRes;
+import com.festival.domain.timetable.dto.TimeTableReq;
+import com.festival.domain.timetable.dto.TimeTableRes;
+import com.festival.domain.timetable.model.TimeTable;
+import com.festival.domain.timetable.repository.TimeTableRepository;
+import com.festival.domain.util.ControllerTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.festival.domain.member.model.MemberRole.ADMIN;
+import static com.festival.domain.member.model.MemberRole.MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class TimeTableControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private TimeTableRepository timeTableRepository;
+
+    private Member member;
+
+    private Member differentMember;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .username("testUser")
+                .password("12345")
+                .memberRole(ADMIN)
+                .build();
+        memberRepository.saveAndFlush(member);
+
+        differentMember = Member.builder()
+                .username("differentUser")
+                .password("12345")
+                .memberRole(MANAGER)
+                .build();
+        memberRepository.saveAndFlush(differentMember);
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("시간표 객체를 생성한다.")
+    @Test
+    void createTimeTable() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+
+        TimeTableReq timeTableReq = createTimeTableReqCount(registeredDateTime, 1);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        post("/api/v2/timetable")
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("title", timeTableReq.getTitle())
+                                .param("startTime", timeTableReq.getStartTime().toString())
+                                .param("endTime", timeTableReq.getEndTime().toString())
+                                .param("status", timeTableReq.getStatus())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"))
+                .andReturn();
+
+        //then
+        Long timeTableId = Long.parseLong(mvcResult.getResponse().getContentAsString());
+        TimeTable findTimeTable = timeTableRepository.findById(timeTableId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_TIMETABLE));
+        assertThat(findTimeTable).isNotNull()
+                .extracting("title", "startTime", "endTime", "status")
+                .containsExactly("testTitle1", registeredDateTime, registeredDateTime.plusHours(1), OperateStatus.OPERATE);
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("시간표 객체를 수정한다.")
+    @Test
+    void updateTimeTable() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+        LocalDateTime updatedDateTime = LocalDateTime.of(2023, 9, 1, 12, 41, 0);
+
+        TimeTableReq timeTableReq = createTimeTableReqCount(registeredDateTime, 1);
+        TimeTable timeTable = TimeTable.of(timeTableReq);
+        timeTable.connectMember(member);
+        TimeTable savedTimeTable = timeTableRepository.saveAndFlush(timeTable);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        put("/api/v2/timetable/{timeTableId}", savedTimeTable.getId())
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("title", "updateTitle")
+                                .param("startTime", updatedDateTime.toString())
+                                .param("endTime", updatedDateTime.plusHours(1).toString())
+                                .param("status", timeTableReq.getStatus())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(savedTimeTable.getId().toString()))
+                .andReturn();
+
+        //then
+        Long timeTableId = Long.parseLong(mvcResult.getResponse().getContentAsString());
+        TimeTable findTimeTable = timeTableRepository.findById(timeTableId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_TIMETABLE));
+        assertThat(findTimeTable).isNotNull()
+                .extracting("title", "startTime", "endTime", "status")
+                .containsExactly("updateTitle", updatedDateTime, updatedDateTime.plusHours(1), OperateStatus.OPERATE);
+    }
+
+    @WithMockUser(username = "differentUser", roles = "MANAGER")
+    @DisplayName("권한이 없는 시간표 객체는 수정할 수 없다.")
+    @Test
+    void updateTimeTableNotMine() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+        LocalDateTime updatedDateTime = LocalDateTime.of(2023, 9, 1, 12, 41, 0);
+
+        TimeTableReq timeTableReq = createTimeTableReqCount(registeredDateTime, 1);
+        TimeTable timeTable = TimeTable.of(timeTableReq);
+        timeTable.connectMember(member);
+        TimeTable savedTimeTable = timeTableRepository.saveAndFlush(timeTable);
+
+        //when //then
+        mockMvc.perform(
+                        put("/api/v2/timetable/{timeTableId}", savedTimeTable.getId())
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("title", "updateTitle")
+                                .param("startTime", updatedDateTime.toString())
+                                .param("endTime", updatedDateTime.plusHours(1).toString())
+                                .param("status", timeTableReq.getStatus())
+                )
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("존재하지 않는 시간표 객체는 수정할 수 없다.")
+    @Test
+    void updateTimeTableNotFound() throws Exception {
+        //when //then
+        mockMvc.perform(
+                        put("/api/v2/timetable/{timeTableId}", 1L)
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("title", "updateTitle")
+                                .param("startTime", LocalDateTime.of(2023, 9, 1, 12, 41, 0).toString())
+                                .param("endTime", LocalDateTime.of(2023, 9, 1, 13, 41, 0).toString())
+                                .param("status", "OPERATE")
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("시간표 객체를 삭제한다.")
+    @Test
+    void deleteTimeTable() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+
+        TimeTableReq timeTableReq = createTimeTableReqCount(registeredDateTime, 1);
+        TimeTable timeTable = TimeTable.of(timeTableReq);
+        timeTable.connectMember(member);
+        TimeTable savedTimeTable = timeTableRepository.saveAndFlush(timeTable);
+
+        //when
+        mockMvc.perform(
+                        delete("/api/v2/timetable/" + savedTimeTable.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //then
+        TimeTable findTimeTable = timeTableRepository.findById(savedTimeTable.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_TIMETABLE));
+        assertThat(findTimeTable.getStatus()).isEqualTo(OperateStatus.TERMINATE);
+    }
+
+    @WithMockUser(username = "differentUser", roles = "MANAGER")
+    @DisplayName("권한이 없는 시간표 객체는 삭제할 수 없다.")
+    @Test
+    void deleteTimeTableNotMine() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+
+        TimeTableReq timeTableReq = createTimeTableReqCount(registeredDateTime, 1);
+        TimeTable timeTable = TimeTable.of(timeTableReq);
+        timeTable.connectMember(member);
+        TimeTable savedTimeTable = timeTableRepository.saveAndFlush(timeTable);
+
+        //when //then
+        mockMvc.perform(
+                        delete("/api/v2/timetable/" + savedTimeTable.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @WithMockUser(username = "testUser", roles = "ADMIN")
+    @DisplayName("존재하지 않는 시간표 객체는 삭제할 수 없다.")
+    @Test
+    void deleteTimeTableNotFound() throws Exception {
+        //when //then
+        mockMvc.perform(
+                        delete("/api/v2/timetable/" + 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("시간표 객체를 목록조회한다. (페이징)")
+    @Test
+    void getTimeTableList() throws Exception {
+        //given
+        LocalDateTime registeredDateTime = LocalDateTime.of(2023, 9, 1, 11, 41, 0);
+
+        TimeTableReq timeTableReq1 = createTimeTableReqCount(registeredDateTime, 1);
+        TimeTableReq timeTableReq2 = createTimeTableReqCount(registeredDateTime, 2);
+        TimeTableReq timeTableReq3 = createTimeTableReqCount(registeredDateTime, 3);
+        TimeTableReq timeTableReq4 = createTimeTableReqCount(registeredDateTime, 4);
+        TimeTableReq timeTableReq5 = createTimeTableReqCount(registeredDateTime, 5);
+        TimeTableReq timeTableReq6 = createTimeTableReqCount(registeredDateTime, 6);
+
+        TimeTable timeTable1 = TimeTable.of(timeTableReq1);
+        timeTable1.connectMember(member);
+        TimeTable timeTable2 = TimeTable.of(timeTableReq2);
+        timeTable2.connectMember(member);
+        TimeTable timeTable3 = TimeTable.of(timeTableReq3);
+        timeTable3.connectMember(member);
+        TimeTable timeTable4 = TimeTable.of(timeTableReq4);
+        timeTable4.connectMember(member);
+        TimeTable timeTable5 = TimeTable.of(timeTableReq5);
+        timeTable5.connectMember(member);
+        TimeTable timeTable6 = TimeTable.of(timeTableReq6);
+        timeTable6.connectMember(member);
+        timeTableRepository.saveAllAndFlush(List.of(timeTable1, timeTable2, timeTable3, timeTable4, timeTable5, timeTable6));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/v2/timetable/list")
+                                .param("startTime", registeredDateTime.toString())
+                                .param("endTime", registeredDateTime.plusDays(1).toString())
+                                .param("status", "OPERATE")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String content = mvcResult.getResponse().getContentAsString();
+        List<TimeTableRes> timeTableResList = objectMapper.readValue(content, objectMapper.getTypeFactory().constructCollectionType(List.class, TimeTableRes.class));
+        assertThat(timeTableResList).hasSize(6)
+                .extracting("title")
+                .containsExactlyInAnyOrder("testTitle1", "testTitle2", "testTitle3", "testTitle4", "testTitle5", "testTitle6");
+    }
+
+    private static TimeTableReq createTimeTableReqCount(LocalDateTime registeredDateTime, int count) {
+        return TimeTableReq.builder()
+                .title("testTitle" + count)
+                .startTime(registeredDateTime)
+                .endTime(registeredDateTime.plusHours(1))
+                .status("OPERATE")
+                .build();
+    }
+}

--- a/src/test/java/com/festival/domain/timetable/service/TimeTableServiceTest.java
+++ b/src/test/java/com/festival/domain/timetable/service/TimeTableServiceTest.java
@@ -56,7 +56,7 @@ class TimeTableServiceTest {
                 .willReturn(getTimeTable());
 
         //when
-        Long timeTableId = timeTableService.create(timeTableReq);
+        Long timeTableId = timeTableService.createTimeTable(timeTableReq);
 
         //then
         Assertions.assertThat(timeTableId).isEqualTo(1L);
@@ -74,7 +74,7 @@ class TimeTableServiceTest {
                 .willReturn(MemberFixture.ADMIN);
 
         //when
-        Long timeTableId = timeTableService.update(1L, timeTableUpdateReqReq);
+        Long timeTableId = timeTableService.updateTimeTable(1L, timeTableUpdateReqReq);
 
         //then
         Assertions.assertThat(timeTableId).isEqualTo(1L);
@@ -93,7 +93,7 @@ class TimeTableServiceTest {
                 .willReturn(MemberFixture.MANAGER1);
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.update(1L, timeTableUpdateReqReq))
+        assertThatThrownBy(() -> timeTableService.updateTimeTable(1L, timeTableUpdateReqReq))
                 .isInstanceOf(ForbiddenException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN_UPDATE);
@@ -112,7 +112,7 @@ class TimeTableServiceTest {
 
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.update(1L, timeTableUpdateReqReq))
+        assertThatThrownBy(() -> timeTableService.updateTimeTable(1L, timeTableUpdateReqReq))
                 .isInstanceOf(NotFoundException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.NOT_FOUND_TIMETABLE);
@@ -128,7 +128,7 @@ class TimeTableServiceTest {
 
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.update(1L, timeTableUpdateReqReq))
+        assertThatThrownBy(() -> timeTableService.updateTimeTable(1L, timeTableUpdateReqReq))
                 .isInstanceOf(AlreadyDeleteException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_DELETED);
@@ -143,7 +143,7 @@ class TimeTableServiceTest {
                 .willReturn(MemberFixture.ADMIN);
 
         //when & then
-        timeTableService.delete(1L);
+        timeTableService.deleteTimeTable(1L);
 
     }
     @DisplayName("권한 없는 사용자가 타임테이블을 삭제 ForbiddenException을 반환한다.")
@@ -156,7 +156,7 @@ class TimeTableServiceTest {
                 .willReturn(MemberFixture.MANAGER1);
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.delete(1L))
+        assertThatThrownBy(() -> timeTableService.deleteTimeTable(1L))
                 .isInstanceOf(ForbiddenException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN_DELETE);
@@ -173,7 +173,7 @@ class TimeTableServiceTest {
                 .willReturn(Optional.empty());
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.delete(1L))
+        assertThatThrownBy(() -> timeTableService.deleteTimeTable(1L))
                 .isInstanceOf(NotFoundException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.NOT_FOUND_TIMETABLE);
@@ -188,7 +188,7 @@ class TimeTableServiceTest {
 
 
         //when & then
-        assertThatThrownBy(() -> timeTableService.delete(1L))
+        assertThatThrownBy(() -> timeTableService.deleteTimeTable(1L))
                 .isInstanceOf(AlreadyDeleteException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_DELETED);


### PR DESCRIPTION
# Issue
- #153 

## Issue 내용
- 시간표 도메인의 통합 테스트 로직을 구현하였습니다.
- 시간표 서비스 메소드의 명을 직관적으로 확인할 수 있도록 기존 메소드 명 뒤에 도메인 이름을 추가하였습니다.
- 시간표 목록 메소드에 입력되는 시작시간, 종료시간이 경계값을 가질 경우에는 포함되지 않는 이슈를 확인하였습니다.
- 경계값도 포함되어 조회되도록 조건을 수정하였습니다.
<img width="586" alt="image" src="https://github.com/miIlicon/WithFestival-BackEnd/assets/26915908/66f45e1d-55b4-4cc2-9cb8-f2cfdc97f335">

after -> goe (Greater than Or Equal to)
before -> loe (Less than Or Equal to)

**PR에서는 시간표 도메인의 리팩토링 사항, 통합 테스트 로직이 적용되었습니다. 확인하시고, 머지해주시면 감사하겠습니다.**