### PR TITLE
[#164] 안내사항 도메인의 로직 개선 사항을 적용한다.

### DIFF
--- a/src/main/java/com/festival/common/util/ValidationUtils.java
+++ b/src/main/java/com/festival/common/util/ValidationUtils.java
@@ -60,7 +60,7 @@ public class ValidationUtils {
     public boolean isGuideValid(GuideReq guide) throws Exception {
         checkStrLength(guide.getTitle(), 1, 20);
         checkStrLength(guide.getContent(), 1, 300);
-        String[] typeList = {"QNA", "NOTICE"};
+        String[] typeList = {"NOTICE"};
         checkTypeItem(typeList, guide.getType());
         checkStatus(guide.getStatus());
         return true;

--- a/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
@@ -2,8 +2,10 @@ package com.festival.domain.bambooforest.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class BamBooForestRes {
     private Long id;
     private String content;

--- a/src/main/java/com/festival/domain/guide/controller/GuideController.java
+++ b/src/main/java/com/festival/domain/guide/controller/GuideController.java
@@ -7,13 +7,9 @@ import com.festival.domain.guide.service.GuideService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,7 +22,7 @@ public class GuideController {
     private final GuideService guideService;
     private final ValidationUtils validationUtils;
 
-    @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
+    @PreAuthorize("hasAuthority({'ADMIN'})")
     @PostMapping
     public ResponseEntity<Long> createGuide(@Valid GuideReq guideReq) throws Exception {
         if (!validationUtils.isGuideValid(guideReq)) {
@@ -36,7 +32,7 @@ public class GuideController {
         return ResponseEntity.ok().body(id);
     }
 
-    @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
+    @PreAuthorize("hasAuthority({'ADMIN'})")
     @PutMapping("/{guideId}")
     public ResponseEntity<Long> updateGuide(@PathVariable Long guideId, @Valid GuideReq guideReq) throws Exception {
         if (!validationUtils.isGuideValid(guideReq)) {
@@ -45,7 +41,7 @@ public class GuideController {
         return ResponseEntity.ok().body(guideService.updateGuide(guideId, guideReq));
     }
 
-    @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
+    @PreAuthorize("hasAuthority({'ADMIN'})")
     @DeleteMapping("/{guideId}")
     public ResponseEntity<Void> deleteGuide(@PathVariable Long guideId) {
         guideService.deleteGuide(guideId);

--- a/src/main/java/com/festival/domain/guide/dto/GuideReq.java
+++ b/src/main/java/com/festival/domain/guide/dto/GuideReq.java
@@ -26,10 +26,8 @@ public class GuideReq {
     @NotNull(message = "상태값을 입력해주세요")
     private String status;
 
-    @NotNull(message = "썸네일 이미지를 선택해주세요")
     private MultipartFile mainFile;
 
-    @NotNull(message = "서브 이미지를 선택해주세요")
     private List<MultipartFile> subFiles;
 
     @Builder

--- a/src/main/java/com/festival/domain/guide/dto/GuideRes.java
+++ b/src/main/java/com/festival/domain/guide/dto/GuideRes.java
@@ -1,7 +1,6 @@
 package com.festival.domain.guide.dto;
 
 import com.festival.domain.guide.model.Guide;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,6 +31,7 @@ public class GuideRes {
 
     public static GuideRes of(Guide guide) {
         return GuideRes.builder()
+                .id(guide.getId())
                 .title(guide.getTitle())
                 .content(guide.getContent())
                 .type(guide.getType().getValue())

--- a/src/main/java/com/festival/domain/guide/model/GuideType.java
+++ b/src/main/java/com/festival/domain/guide/model/GuideType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum GuideType {
-    QNA("QNA"),
+
     NOTICE("NOTICE");
 
     private String value;
@@ -15,7 +15,6 @@ public enum GuideType {
 
     public static GuideType checkType(String type) {
         return switch (type) {
-            case "QNA" -> GuideType.QNA;
             case "NOTICE" -> GuideType.NOTICE;
             default -> null;
         };

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -2,7 +2,6 @@ package com.festival.domain.guide.service;
 
 import com.festival.common.base.OperateStatus;
 import com.festival.common.exception.custom_exception.AlreadyDeleteException;
-import com.festival.common.exception.custom_exception.BadRequestException;
 import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
 import com.festival.common.util.SecurityUtils;
@@ -45,9 +44,9 @@ public class GuideService {
     @Transactional
     public Long updateGuide(Long id, GuideReq guideReq) {
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
-        Member findMember = memberService.getAuthenticationMember();
 
-        if (!SecurityUtils.checkingRole(guide.getMember(), memberService.getAuthenticationMember())) {
+        Member findMember = memberService.getAuthenticationMember();
+        if (!SecurityUtils.checkingAdminRole(memberService.getAuthenticationMember().getMemberRoles())) {
             throw new ForbiddenException(FORBIDDEN_UPDATE);
         }
         guide.update(guideReq);
@@ -60,7 +59,7 @@ public class GuideService {
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
 
         Member findMember = memberService.getAuthenticationMember();
-        if (!SecurityUtils.checkingRole(guide.getMember(), memberService.getAuthenticationMember())) {
+        if (!SecurityUtils.checkingAdminRole(memberService.getAuthenticationMember().getMemberRoles())) {
             throw new ForbiddenException(FORBIDDEN_DELETE);
         }
 

--- a/src/test/java/com/festival/domain/guide/controller/GuideControllerTest.java
+++ b/src/test/java/com/festival/domain/guide/controller/GuideControllerTest.java
@@ -25,7 +25,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.util.List;
 
 import static com.festival.domain.guide.model.GuideType.NOTICE;
-import static com.festival.domain.guide.model.GuideType.QNA;
 import static com.festival.domain.member.model.MemberRole.ADMIN;
 import static com.festival.domain.member.model.MemberRole.MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,7 +76,7 @@ class GuideControllerTest extends ControllerTestSupport {
         GuideReq guideReq = GuideReq.builder()
                 .title("title")
                 .content("content")
-                .type("QNA")
+                .type("NOTICE")
                 .status("OPERATE")
                 .build();
 
@@ -104,7 +103,7 @@ class GuideControllerTest extends ControllerTestSupport {
         Guide findGuide = guideRepository.findById(id).get();
         assertThat(findGuide).isNotNull()
                 .extracting("title", "content", "type", "status")
-                .contains("title", "content", QNA, OperateStatus.OPERATE);
+                .contains("title", "content", NOTICE, OperateStatus.OPERATE);
     }
 
     @WithMockUser(username = "testUser", roles = "ADMIN")
@@ -122,7 +121,7 @@ class GuideControllerTest extends ControllerTestSupport {
         GuideReq guideReq = GuideReq.builder()
                 .title("title")
                 .content("content")
-                .type("QNA")
+                .type("NOTICE")
                 .status("OPERATE")
                 .build();
         Guide guide = Guide.of(guideReq);
@@ -201,7 +200,7 @@ class GuideControllerTest extends ControllerTestSupport {
                 TestImageUtils.generateMockImageFile("subFiles")
         );
 
-        Guide guide = createGuideEntity("title", "content", "QNA", "OPERATE");
+        Guide guide = createGuideEntity("title", "content", "NOTICE", "OPERATE");
         guide.connectMember(member);
         Guide savedGuide = guideRepository.saveAndFlush(guide);
 
@@ -231,7 +230,7 @@ class GuideControllerTest extends ControllerTestSupport {
     @Test
     void deleteGuide() throws Exception {
         //given
-        Guide guide = createGuideEntity("title", "content", "QNA", "OPERATE");
+        Guide guide = createGuideEntity("title", "content", "NOTICE", "OPERATE");
         guide.connectMember(member);
         Guide savedGuide = guideRepository.saveAndFlush(guide);
 
@@ -266,7 +265,7 @@ class GuideControllerTest extends ControllerTestSupport {
     @Test
     void NotDeleteDifferentUser() throws Exception {
         //given
-        Guide guide = createGuideEntity("title", "content", "QNA", "OPERATE");
+        Guide guide = createGuideEntity("title", "content", "NOTICE", "OPERATE");
         guide.connectMember(member);
         Guide savedGuide = guideRepository.saveAndFlush(guide);
 
@@ -295,7 +294,7 @@ class GuideControllerTest extends ControllerTestSupport {
     @Test
     void getGuide() throws Exception {
         //given
-        Guide guide = createGuideEntity("title", "content", "QNA", "OPERATE");
+        Guide guide = createGuideEntity("title", "content", "NOTICE", "OPERATE");
         Image image = Image.builder()
                 .mainFilePath("/mainFile213")
                 .subFilePaths(List.of("/subFile1123", "/subFile2123"))
@@ -319,7 +318,7 @@ class GuideControllerTest extends ControllerTestSupport {
         GuideRes guideRes = objectMapper.readValue(content, GuideRes.class);
         assertThat(guideRes).isNotNull()
                 .extracting("title", "content", "type")
-                .contains("title", "content", "QNA"
+                .contains("title", "content", "NOTICE"
         );
     }
 
@@ -330,19 +329,19 @@ class GuideControllerTest extends ControllerTestSupport {
         String status = "OPERATE";
         Pageable pageable = PageRequest.of(0, 5);
 
-        Guide guide1 = createGuideEntity("title1", "content1", "QNA", "OPERATE");
+        Guide guide1 = createGuideEntity("title1", "content1", "NOTICE", "OPERATE");
         guide1.setImage(ImageFixture.IMAGE);
         Guide guide2 = createGuideEntity("title2", "content2", "NOTICE", "OPERATE");
         guide2.setImage(ImageFixture.IMAGE);
-        Guide guide3 = createGuideEntity("title3", "content3", "QNA", "OPERATE");
+        Guide guide3 = createGuideEntity("title3", "content3", "NOTICE", "OPERATE");
         guide3.setImage(ImageFixture.IMAGE);
         Guide guide4 = createGuideEntity("title4", "content4", "NOTICE", "OPERATE");
         guide4.setImage(ImageFixture.IMAGE);
-        Guide guide5 = createGuideEntity("title5", "content5", "QNA", "OPERATE");
+        Guide guide5 = createGuideEntity("title5", "content5", "NOTICE", "OPERATE");
         guide5.setImage(ImageFixture.IMAGE);
         Guide guide6 = createGuideEntity("title6", "content6", "NOTICE", "OPERATE");
         guide6.setImage(ImageFixture.IMAGE);
-        Guide guide7 = createGuideEntity("title7", "content7", "QNA", "OPERATE");
+        Guide guide7 = createGuideEntity("title7", "content7", "NOTICE", "OPERATE");
         guide7.setImage(ImageFixture.IMAGE);
         Guide guide8 = createGuideEntity("title8", "content8", "NOTICE", "OPERATE");
         guide8.setImage(ImageFixture.IMAGE);
@@ -368,11 +367,11 @@ class GuideControllerTest extends ControllerTestSupport {
         assertThat(guideResList).hasSize(5)
                 .extracting("title", "content", "type")
                 .containsExactlyInAnyOrder(
-                        tuple("title1", "content1", "QNA"),
+                        tuple("title1", "content1", "NOTICE"),
                         tuple("title2", "content2", "NOTICE"),
-                        tuple("title3", "content3", "QNA"),
+                        tuple("title3", "content3", "NOTICE"),
                         tuple("title4", "content4", "NOTICE"),
-                        tuple("title5", "content5", "QNA")
+                        tuple("title5", "content5", "NOTICE")
                 );
     }
 

--- a/src/test/java/com/festival/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/com/festival/domain/guide/service/GuideServiceTest.java
@@ -123,12 +123,12 @@ class GuideServiceTest {
         //given
         GuideReq guideUpdateReq = getGuideUpdateReq();
         Guide guide = getGuide();
-        guide.connectMember(MemberFixture.MANAGER1);
+        guide.connectMember(MemberFixture.ADMIN);
 
         given(guideRepository.findById(1L))
                 .willReturn(Optional.of(guide));
         given(memberService.getAuthenticationMember())
-                .willReturn(MemberFixture.MANAGER1);
+                .willReturn(MemberFixture.ADMIN);
 
         //when
         Long guideId = guideService.updateGuide(1L, guideUpdateReq);
@@ -204,12 +204,12 @@ class GuideServiceTest {
     void deleteGuide4(){
         //given
         Guide guide = getGuide();
-        guide.connectMember(MemberFixture.MANAGER1);
+        guide.connectMember(MemberFixture.ADMIN);
 
         given(guideRepository.findById(1L))
                 .willReturn(Optional.of(guide));
         given(memberService.getAuthenticationMember())
-                .willReturn(MemberFixture.MANAGER1);
+                .willReturn(MemberFixture.ADMIN);
 
         //when && then
         guideService.deleteGuide(1L);


### PR DESCRIPTION
# Issue
- #164 

## Issue 내용
- 안내사항 상태값 중 QNA 상태를 제거했습니다.
- 안내사항의 권한 체크 로직에서 MANAGER를 제외한 ADMIN의 권한만 허용되도록 리팩토링 했습니다.
- 안내사항 도메인에서 이미지는 필수사항이 아니므로 이미지 검증 어노테이션을 제거하였습니다.