### PR TITLE
[#176] 도메인별 조회수 증감 로직을 리팩토링한다.

### DIFF
--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -1,9 +1,10 @@
 package com.festival.common.scheduler;
 
 import com.festival.common.redis.RedisService;
+import com.festival.domain.booth.service.BoothService;
 import com.festival.domain.guide.service.GuideService;
+import com.festival.domain.program.service.ProgramService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,9 +17,11 @@ import java.util.Set;
 public class SchedulerRunner {
 
     private final RedisService redisService;
-    private final GuideService guideService;
 
-    // 1 hour
+    private final GuideService guideService;
+    private final BoothService boothService;
+    private final ProgramService programService;
+
     @Scheduled(fixedDelay = 3600000)
     public void updateViewCount()
     {
@@ -27,15 +30,17 @@ public class SchedulerRunner {
             String[] splitKey = key.split("_");
             switch (splitKey[0]) {
                 case "Booth" -> {
+                    boothService.increaseBoothViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    redisService.deleteData(key);
                 }
                 case "Guide" -> {
                     guideService.increaseGuideViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Program" -> {
-
+                    programService.increaseProgramViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    redisService.deleteData(key);
                 }
-
             }
         }
 

--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -52,7 +52,7 @@ public class BoothController {
     @PreAuthorize("permitAll()")
     @GetMapping("/{boothId}")
     public ResponseEntity<BoothRes> getBooth(@PathVariable("boothId") Long id, HttpServletRequest httpServletRequest) {
-        return ResponseEntity.ok().body(boothService.getBooth(id, httpServletRequest.getHeader("X-Forwarded-For")));
+        return ResponseEntity.ok().body(boothService.getBooth(id,httpServletRequest.getLocalAddr()));
     }
 
     @PreAuthorize("permitAll()")

--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -14,8 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v2/booth")
@@ -52,7 +50,7 @@ public class BoothController {
     @PreAuthorize("permitAll()")
     @GetMapping("/{boothId}")
     public ResponseEntity<BoothRes> getBooth(@PathVariable("boothId") Long id, HttpServletRequest httpServletRequest) {
-        return ResponseEntity.ok().body(boothService.getBooth(id,httpServletRequest.getLocalAddr()));
+        return ResponseEntity.ok().body(boothService.getBooth(id,httpServletRequest.getRemoteAddr()));
     }
 
     @PreAuthorize("permitAll()")

--- a/src/main/java/com/festival/domain/booth/model/Booth.java
+++ b/src/main/java/com/festival/domain/booth/model/Booth.java
@@ -46,6 +46,9 @@ public class Booth extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     @Builder
     private Booth(String title, String subTitle, String content, float latitude, float longitude, OperateStatus status, BoothType type) {
         this.title = title;
@@ -87,5 +90,13 @@ public class Booth extends BaseEntity {
 
     public void changeStatus(OperateStatus status) {
         this.status = status;
+    }
+
+    public void increaseViewCount(Long viewCount) {
+        this.viewCount += viewCount;
+    }
+
+    public void decreaseViewCount(Long viewCount) {
+        this.viewCount -= viewCount;
     }
 }

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -83,14 +83,10 @@ public class BoothService {
 
     }
 
-    private Booth checkingDeletedStatus(Optional<Booth> booth) {
-        if (booth.isEmpty()) {
-            throw new NotFoundException(NOT_FOUND_BOOTH);
-        }
-        if (booth.get().getStatus() == OperateStatus.TERMINATE) {
-            throw new AlreadyDeleteException(ALREADY_DELETED);
-        }
-        return booth.get();
+    @Transactional
+    public void increaseBoothViewCount(Long id, Long viewCount) {
+        Booth booth = boothRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOTH));
+        booth.increaseViewCount(viewCount);
     }
 
 }

--- a/src/main/java/com/festival/domain/guide/controller/GuideController.java
+++ b/src/main/java/com/festival/domain/guide/controller/GuideController.java
@@ -50,7 +50,7 @@ public class GuideController {
     @PreAuthorize("permitAll()")
     @GetMapping("/{guideId}")
     public ResponseEntity<GuideRes> getGuide(@PathVariable Long guideId, HttpServletRequest httpServletRequest) {
-        return ResponseEntity.ok().body(guideService.getGuide(guideId, httpServletRequest.getLocalAddr()));
+        return ResponseEntity.ok().body(guideService.getGuide(guideId, httpServletRequest.getRemoteAddr()));
     }
 
     @PreAuthorize("permitAll()")

--- a/src/main/java/com/festival/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/festival/domain/program/controller/ProgramController.java
@@ -6,6 +6,7 @@ import com.festival.domain.program.dto.ProgramPageRes;
 import com.festival.domain.program.dto.ProgramReq;
 import com.festival.domain.program.dto.ProgramRes;
 import com.festival.domain.program.service.ProgramService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -51,8 +52,8 @@ public class ProgramController {
 
     @PreAuthorize("permitAll()")
     @GetMapping("/{programId}")
-    public ResponseEntity<ProgramRes> getProgram(@PathVariable Long programId) {
-        return ResponseEntity.ok().body(programService.getProgram(programId));
+    public ResponseEntity<ProgramRes> getProgram(@PathVariable Long programId, HttpServletRequest httpServletRequest) {
+        return ResponseEntity.ok().body(programService.getProgram(programId, httpServletRequest.getRemoteAddr()));
     }
 
     @PreAuthorize("permitAll()")

--- a/src/main/java/com/festival/domain/program/model/Program.java
+++ b/src/main/java/com/festival/domain/program/model/Program.java
@@ -47,6 +47,9 @@ public class Program extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     @Builder
     private Program(Long id, String title, String subTitle, String content, float latitude, float longitude, OperateStatus status, ProgramType type) {
         this.id = id;
@@ -91,5 +94,13 @@ public class Program extends BaseEntity {
 
     public void connectMember(Member member){
         this.member = member;
+    }
+
+    public void increaseViewCount(Long viewCount) {
+        this.viewCount += viewCount;
+    }
+
+    public void decreaseViewCount(Long viewCount) {
+        this.viewCount -= viewCount;
     }
 }


### PR DESCRIPTION
# Issue 
- #176 

## Issue 내용
- 안내사항 도메인에만 적용되던 조회수 증감 로직을 다른 도메인에도 적용시켰습니다.
- 클라이언트의 ip를 받아와서 그값을 redis에 저장하여 게시물 별 조회수 중복을 확인하도록 로직을 구성하였습니다.
- **Domain이름_Id_게시물Number** 형식