### PR TITLE
[#180] 컨트롤러계층에서 throw문 제거

### DIFF
--- a/src/main/java/com/festival/common/util/ValidationUtils.java
+++ b/src/main/java/com/festival/common/util/ValidationUtils.java
@@ -27,6 +27,49 @@ public class ValidationUtils {
     private static final String DATE_PATTERN =
             "^([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:([0-5][0-9])$";
 
+    public void isGuideValid(GuideReq guide) {
+        checkStrLength(guide.getTitle(), 1, 20);
+        checkStrLength(guide.getContent(), 1, 300);
+        String[] typeList = {"NOTICE"};
+        checkTypeItem(typeList, guide.getType());
+        checkStatus(guide.getStatus());
+    }
+
+    public void isBoothValid(BoothReq booth) {
+        checkStrLength(booth.getTitle(), 1, 30);
+        checkStrLength(booth.getSubTitle(), 1, 50);
+        checkStrLength(booth.getContent(), 1, 300);
+        checkNumberRange(booth.getLatitude(), -90.0, 90.0);
+        checkNumberRange(booth.getLongitude(), -180, 180);
+        String[] typeList = {"FOOD_TRUCK", "FLEA_MARKET", "PUB"};
+        checkTypeItem(typeList, booth.getType());
+        checkStatus(booth.getStatus());
+    }
+
+    public void isProgramValid(ProgramReq program) {
+        checkStrLength(program.getTitle(), 1, 30);
+        checkStrLength(program.getSubTitle(), 1, 50);
+        checkStrLength(program.getContent(), 1, 300);
+        checkNumberRange(program.getLatitude(), -90.0, 90.0);
+        checkNumberRange(program.getLongitude(), -180, 180);
+        String[] typeList = {"EVENT", "GAME"};
+        checkTypeItem(typeList, program.getType());
+        checkStatus(program.getStatus());
+    }
+
+    public void isTimeTableValid(TimeTableReq timeTable) {
+        checkItemPattern(timeTable.getStartTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), DATE_PATTERN);
+        checkItemPattern(timeTable.getEndTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), DATE_PATTERN);
+        checkStrLength(timeTable.getTitle(), 1, 30);
+        checkStatus(timeTable.getStatus());
+    }
+
+    public void isBamBooForestValid(BamBooForestReq bamBooForest) {
+        checkStrLength(bamBooForest.getContent(), 1, 200);
+        checkItemPattern(bamBooForest.getContact(), EMAIL_REGEX);
+        checkStatus(bamBooForest.getStatus());
+    }
+
     private void checkStrLength(String str, int min, int max) {
         int strlen = str.length();
         if (min > strlen || max < strlen) {
@@ -58,60 +101,9 @@ public class ValidationUtils {
         Pattern pattern = Pattern.compile(itemPattern);
         if (!pattern.matcher(item).matches()) {
             switch (itemPattern) {
-                case EMAIL_REGEX:
-                    throw new InvalidException(ErrorCode.INVALID_DATE);
-                case DATE_PATTERN:
-                    throw new InvalidException(ErrorCode.INVALID_EMAIL);
+                case EMAIL_REGEX -> throw new InvalidException(ErrorCode.INVALID_DATE);
+                case DATE_PATTERN -> throw new InvalidException(ErrorCode.INVALID_EMAIL);
             }
         }
     }
-
-    public boolean isGuideValid(GuideReq guide) {
-        checkStrLength(guide.getTitle(), 1, 20);
-        checkStrLength(guide.getContent(), 1, 300);
-        String[] typeList = {"NOTICE"};
-        checkTypeItem(typeList, guide.getType());
-        checkStatus(guide.getStatus());
-        return true;
-    }
-
-    public boolean isBoothValid(BoothReq booth) {
-        checkStrLength(booth.getTitle(), 1, 30);
-        checkStrLength(booth.getSubTitle(), 1, 50);
-        checkStrLength(booth.getContent(), 1, 300);
-        checkNumberRange(booth.getLatitude(), -90.0, 90.0);
-        checkNumberRange(booth.getLongitude(), -180, 180);
-        String[] typeList = {"FOOD_TRUCK", "FLEA_MARKET", "PUB"};
-        checkTypeItem(typeList, booth.getType());
-        checkStatus(booth.getStatus());
-        return true;
-    }
-
-    public boolean isProgramValid(ProgramReq program) {
-        checkStrLength(program.getTitle(), 1, 30);
-        checkStrLength(program.getSubTitle(), 1, 50);
-        checkStrLength(program.getContent(), 1, 300);
-        checkNumberRange(program.getLatitude(), -90.0, 90.0);
-        checkNumberRange(program.getLongitude(), -180, 180);
-        String[] typeList = {"EVENT", "GAME"};
-        checkTypeItem(typeList, program.getType());
-        checkStatus(program.getStatus());
-        return true;
-    }
-
-    public boolean isTimeTableValid(TimeTableReq timeTable) {
-        checkItemPattern(timeTable.getStartTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), DATE_PATTERN);
-        checkItemPattern(timeTable.getEndTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), DATE_PATTERN);
-        checkStrLength(timeTable.getTitle(), 1, 30);
-        checkStatus(timeTable.getStatus());
-        return true;
-    }
-
-    public boolean isBamBooForestValid(BamBooForestReq bamBooForest) {
-        checkStrLength(bamBooForest.getContent(), 1, 200);
-        checkItemPattern(bamBooForest.getContact(), EMAIL_REGEX);
-        checkStatus(bamBooForest.getStatus());
-        return true;
-    }
-
 }

--- a/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
+++ b/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
@@ -22,10 +22,8 @@ public class BambooForestController {
 
     @PreAuthorize("permitAll()")
     @PostMapping
-    public ResponseEntity<Long> createBamBooForest(@Valid BamBooForestReq bamBooForestReq) throws Exception {
-        if (!validationUtils.isBamBooForestValid(bamBooForestReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> createBamBooForest(@Valid BamBooForestReq bamBooForestReq) {
+        validationUtils.isBamBooForestValid(bamBooForestReq);
         return ResponseEntity.ok().body(bambooForestService.createBamBooForest(bamBooForestReq));
     }
 

--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -24,19 +24,15 @@ public class BoothController {
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PostMapping
-    public ResponseEntity<Long> createBooth(@Valid BoothReq boothReq) throws Exception {
-        if (!validationUtils.isBoothValid(boothReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> createBooth(@Valid BoothReq boothReq) {
+        validationUtils.isBoothValid(boothReq);
         return ResponseEntity.ok().body(boothService.createBooth(boothReq));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PutMapping("/{boothId}")
-    public ResponseEntity<Long> updateBooth(@Valid BoothReq boothReq, @PathVariable("boothId") Long id) throws Exception {
-        if (!validationUtils.isBoothValid(boothReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> updateBooth(@Valid BoothReq boothReq, @PathVariable("boothId") Long id) {
+        validationUtils.isBoothValid(boothReq);
         return ResponseEntity.ok().body(boothService.updateBooth(boothReq, id));
     }
 

--- a/src/main/java/com/festival/domain/guide/controller/GuideController.java
+++ b/src/main/java/com/festival/domain/guide/controller/GuideController.java
@@ -24,19 +24,15 @@ public class GuideController {
 
     @PreAuthorize("hasAuthority({'ADMIN'})")
     @PostMapping
-    public ResponseEntity<Long> createGuide(@Valid GuideReq guideReq) throws Exception {
-        if (!validationUtils.isGuideValid(guideReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> createGuide(@Valid GuideReq guideReq) {
+        validationUtils.isGuideValid(guideReq);
         return ResponseEntity.ok().body(guideService.createGuide(guideReq));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN'})")
     @PutMapping("/{guideId}")
-    public ResponseEntity<Long> updateGuide(@PathVariable Long guideId, @Valid GuideReq guideReq) throws Exception {
-        if (!validationUtils.isGuideValid(guideReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> updateGuide(@PathVariable Long guideId, @Valid GuideReq guideReq) {
+        validationUtils.isGuideValid(guideReq);
         return ResponseEntity.ok().body(guideService.updateGuide(guideId, guideReq));
     }
 

--- a/src/main/java/com/festival/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/festival/domain/program/controller/ProgramController.java
@@ -14,8 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/program")
@@ -26,20 +24,15 @@ public class ProgramController {
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PostMapping
-    public ResponseEntity<Long> createProgram(@Valid ProgramReq programReqDto) throws Exception {
-        if (!validationUtils.isProgramValid(programReqDto)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> createProgram(@Valid ProgramReq programReqDto) {
+        validationUtils.isProgramValid(programReqDto);
         return ResponseEntity.ok().body(programService.createProgram(programReqDto));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN', 'MANAGER'})")
     @PutMapping("/{programId}")
-    public ResponseEntity<Long> updateProgram(@PathVariable Long programId,
-                                       @Valid ProgramReq programReqDto) throws Exception {
-        if (!validationUtils.isProgramValid(programReqDto)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> updateProgram(@PathVariable Long programId, @Valid ProgramReq programReqDto) {
+        validationUtils.isProgramValid(programReqDto);
         return ResponseEntity.ok().body(programService.updateProgram(programId, programReqDto));
     }
 

--- a/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
+++ b/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
@@ -23,20 +23,16 @@ public class TimeTableController {
 
     @PreAuthorize("hasAuthority({'ADMIN'})")
     @PostMapping
-    public ResponseEntity<Long> createTimeTable(@Valid TimeTableReq timeTableReq) throws Exception {
-        if (!validationUtils.isTimeTableValid(timeTableReq)) {
-            throw new Exception();
-        }
+    public ResponseEntity<Long> createTimeTable(@Valid TimeTableReq timeTableReq) {
+        validationUtils.isTimeTableValid(timeTableReq);
         return ResponseEntity.ok().body(timeTableService.createTimeTable(timeTableReq));
     }
 
     @PreAuthorize("hasAuthority({'ADMIN'})")
     @PutMapping("/{timeTableId}")
     public ResponseEntity<Long> updateTimeTable(@PathVariable Long timeTableId,
-                                                @Valid TimeTableReq timeTableReq) throws Exception {
-        if (!validationUtils.isTimeTableValid(timeTableReq)) {
-            throw new Exception();
-        }
+                                                @Valid TimeTableReq timeTableReq) {
+        validationUtils.isTimeTableValid(timeTableReq);
         return ResponseEntity.ok().body(timeTableService.updateTimeTable(timeTableId, timeTableReq));
     }
 


### PR DESCRIPTION
# Issue
- #180 

## Issue 내용
- 커스텀 검증 클래스에서 각 예외 사항 발생시에 커스텀 exception을 throw하고 있는데, 해당 메소드가 실행되는 컨트롤러 계층에서도 exception을 던지고 있었습니다.
- 커스텀 exception이 터진다면 trycatch문이 아닌이상 해당 throw를 잡을 수 없기 때문에 불필요하다 생각하여
- 컨트롤러계층에서 throw 로직을 제거하였습니다.
- 커스텀 검증 클래스에서 private 메소드들을 하단으로 옮기고 public 메소드가 상단에 표시되도록 수정하였습니다.


**PR을 확인하시고, 고쳐야할 점이 있다면 말씀해 주시면 감사하겠습니다.**