### PR TITLE
[#180] 각 도메인에 대한 통합 검색 로직을 추가한다.

### DIFF
--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -1,10 +1,7 @@
 package com.festival.domain.booth.controller;
 
 import com.festival.common.util.ValidationUtils;
-import com.festival.domain.booth.controller.dto.BoothListReq;
-import com.festival.domain.booth.controller.dto.BoothPageRes;
-import com.festival.domain.booth.controller.dto.BoothReq;
-import com.festival.domain.booth.controller.dto.BoothRes;
+import com.festival.domain.booth.controller.dto.*;
 import com.festival.domain.booth.service.BoothService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -13,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -53,5 +52,10 @@ public class BoothController {
     @GetMapping("/list")
     public ResponseEntity<BoothPageRes> getBoothList(@Valid BoothListReq boothListReq, Pageable pageable) {
         return ResponseEntity.ok().body(boothService.getBoothList(boothListReq, pageable));
+    }
+    @PreAuthorize("permitAll()")
+    @GetMapping("/search")
+    public ResponseEntity<List<BoothSearchRes>> searchBoothList(@RequestParam(name = "keyword") String keyword){
+        return ResponseEntity.ok().body(boothService.searchBoothList(keyword));
     }
 }

--- a/src/main/java/com/festival/domain/booth/controller/dto/BoothRes.java
+++ b/src/main/java/com/festival/domain/booth/controller/dto/BoothRes.java
@@ -2,39 +2,26 @@ package com.festival.domain.booth.controller.dto;
 
 import com.festival.domain.booth.model.Booth;
 import com.querydsl.core.annotations.QueryProjection;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class BoothRes {
-
     private Long id;
-
     private String title;
-
     private String subTitle;
-
     private String content;
-
     private float latitude;
-
     private float longitude;
-
     private String status;
-
     private String type;
-
     private String mainFilePath;
-
     private List<String> subFilePaths;
+
     @Builder
     @QueryProjection
     public BoothRes(Long id, String title, String subTitle, String content, float latitude, float longitude, String status, String type, String mainFilePath, List<String> subFilePaths) {
@@ -50,11 +37,9 @@ public class BoothRes {
         this.subFilePaths = subFilePaths;
     }
 
-
-
-
     public static BoothRes of(Booth booth){
         return BoothRes.builder()
+                .id(booth.getId())
                 .title(booth.getTitle())
                 .subTitle(booth.getSubTitle())
                 .content(booth.getContent())

--- a/src/main/java/com/festival/domain/booth/controller/dto/BoothSearchRes.java
+++ b/src/main/java/com/festival/domain/booth/controller/dto/BoothSearchRes.java
@@ -1,0 +1,26 @@
+package com.festival.domain.booth.controller.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BoothSearchRes {
+
+    private Long id;
+    private String title;
+    private String subTitle;
+    private String status;
+    private String mainFilePath;
+
+    @QueryProjection
+    public BoothSearchRes(Long id, String title, String subTitle, String status, String mainFilePath) {
+        this.id = id;
+        this.title = title;
+        this.subTitle = subTitle;
+        this.status = status;
+        this.mainFilePath = mainFilePath;
+    }
+
+}

--- a/src/main/java/com/festival/domain/booth/repository/BoothRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/booth/repository/BoothRepositoryCustom.java
@@ -5,9 +5,10 @@ import com.festival.domain.booth.controller.dto.BoothRes;
 import com.festival.domain.booth.model.Booth;
 import com.festival.domain.booth.service.vo.BoothListSearchCond;
 import org.springframework.data.domain.Pageable;
-
+import com.festival.domain.booth.controller.dto.BoothSearchRes;
 import java.util.List;
 
 public interface BoothRepositoryCustom {
     BoothPageRes getList(BoothListSearchCond boothListSearchCond);
+    List<BoothSearchRes> searchBoothList(String keyword);
 }

--- a/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
@@ -50,10 +50,13 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
     private static BooleanExpression eqType(String type) {
         return type == null ? null : booth.type.eq(BoothType.valueOf(type));
     }
+
     private static BooleanExpression statusEq(String status) {
         return booth.status.stringValue().eq(status);
     }
+
     private static BooleanExpression eqStatus(String status) {
         return status == null ? null : booth.status.stringValue().eq(status);
     }
+
 }

--- a/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
@@ -1,9 +1,13 @@
-package com.festival.domain.booth.repository;
+package com.festival.domain.booth.repository.impl;
 
 import com.festival.domain.booth.controller.dto.BoothPageRes;
+import com.festival.domain.booth.controller.dto.BoothSearchRes;
+import com.festival.domain.booth.controller.dto.QBoothSearchRes;
 import com.festival.domain.booth.model.Booth;
 import com.festival.domain.booth.model.BoothType;
+import com.festival.domain.booth.repository.BoothRepositoryCustom;
 import com.festival.domain.booth.service.vo.BoothListSearchCond;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -45,6 +49,27 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
 
         Page<Booth> page = PageableExecutionUtils.getPage(result, boothListSearchCond.getPageable(), countQuery::fetchOne);
         return BoothPageRes.of(page);
+    }
+
+    @Override
+    public List<BoothSearchRes> searchBoothList(String keyword) {
+       return queryFactory
+               .select(new QBoothSearchRes(
+                        booth.id,
+                        booth.title,
+                        booth.subTitle,
+                        booth.status.stringValue(),
+                        booth.image.mainFilePath
+                ))
+                .from(booth)
+                .where(
+                        eqKeyword(keyword)
+                )
+                .fetch();
+    }
+
+    private static BooleanExpression eqKeyword(String keyword) {
+        return booth.title.contains(keyword).or(booth.subTitle.contains(keyword));
     }
 
     private static BooleanExpression eqType(String type) {

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -6,10 +6,7 @@ import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
 import com.festival.common.redis.RedisService;
 import com.festival.common.util.SecurityUtils;
-import com.festival.domain.booth.controller.dto.BoothListReq;
-import com.festival.domain.booth.controller.dto.BoothPageRes;
-import com.festival.domain.booth.controller.dto.BoothReq;
-import com.festival.domain.booth.controller.dto.BoothRes;
+import com.festival.domain.booth.controller.dto.*;
 import com.festival.domain.booth.model.Booth;
 import com.festival.domain.booth.repository.BoothRepository;
 import com.festival.domain.booth.service.vo.BoothListSearchCond;
@@ -20,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.festival.common.exception.ErrorCode.*;
@@ -30,6 +28,7 @@ import static com.festival.common.exception.ErrorCode.*;
 public class BoothService {
 
     private final BoothRepository boothRepository;
+
     private final RedisService redisService;
     private final ImageService imageService;
     private final MemberService memberService;
@@ -83,13 +82,16 @@ public class BoothService {
 
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
+    public List<BoothSearchRes> searchBoothList(String keyword) {
+        return boothRepository.searchBoothList(keyword);
+    }
+
     public void increaseBoothViewCount(Long id, Long viewCount) {
         Booth booth = boothRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOTH));
         booth.increaseViewCount(viewCount);
     }
 
-    @Transactional
     public void decreaseBoothViewCount(Long id, Long viewCount) {
         Booth booth = boothRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOTH));
         booth.decreaseViewCount(viewCount);

--- a/src/main/java/com/festival/domain/guide/dto/GuideRes.java
+++ b/src/main/java/com/festival/domain/guide/dto/GuideRes.java
@@ -28,7 +28,6 @@ public class GuideRes {
         this.subFilePaths = subFilePaths;
     }
 
-
     public static GuideRes of(Guide guide) {
         return GuideRes.builder()
                 .id(guide.getId())

--- a/src/main/java/com/festival/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/festival/domain/program/controller/ProgramController.java
@@ -1,10 +1,7 @@
 package com.festival.domain.program.controller;
 
 import com.festival.common.util.ValidationUtils;
-import com.festival.domain.program.dto.ProgramListReq;
-import com.festival.domain.program.dto.ProgramPageRes;
-import com.festival.domain.program.dto.ProgramReq;
-import com.festival.domain.program.dto.ProgramRes;
+import com.festival.domain.program.dto.*;
 import com.festival.domain.program.service.ProgramService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -13,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,6 +52,12 @@ public class ProgramController {
     @GetMapping("/list")
     public ResponseEntity<ProgramPageRes> getProgramList(@Valid ProgramListReq programListReqDto, Pageable pageable) {
         return ResponseEntity.ok().body(programService.getProgramList(programListReqDto, pageable));
+    }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/search")
+    public ResponseEntity<List<ProgramSearchRes>> searchProgramList(@RequestParam(name = "keyword") String keyword) {
+        return ResponseEntity.ok().body(programService.searchProgramList(keyword));
     }
 
 }

--- a/src/main/java/com/festival/domain/program/dto/ProgramRes.java
+++ b/src/main/java/com/festival/domain/program/dto/ProgramRes.java
@@ -1,7 +1,6 @@
 package com.festival.domain.program.dto;
 
 import com.festival.domain.program.model.Program;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProgramRes {
+    private Long id;
     private String title;
     private String subTitle;
     private String content;
@@ -26,6 +26,7 @@ public class ProgramRes {
 
     public static ProgramRes of(Program program) {
         return ProgramRes.builder()
+                .id(program.getId())
                 .title(program.getTitle())
                 .subTitle(program.getSubTitle())
                 .content(program.getContent())

--- a/src/main/java/com/festival/domain/program/dto/ProgramSearchRes.java
+++ b/src/main/java/com/festival/domain/program/dto/ProgramSearchRes.java
@@ -1,0 +1,26 @@
+package com.festival.domain.program.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProgramSearchRes {
+
+    private Long id;
+    private String title;
+    private String subTitle;
+    private String status;
+    private String mainFilePath;
+
+    @QueryProjection
+    public ProgramSearchRes(Long id, String title, String subTitle, String status, String mainFilePath) {
+        this.id = id;
+        this.title = title;
+        this.subTitle = subTitle;
+        this.status = status;
+        this.mainFilePath = mainFilePath;
+    }
+
+}

--- a/src/main/java/com/festival/domain/program/repository/ProgramRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/program/repository/ProgramRepositoryCustom.java
@@ -1,11 +1,12 @@
 package com.festival.domain.program.repository;
 
 import com.festival.domain.program.dto.ProgramPageRes;
-import com.festival.domain.program.model.Program;
+import com.festival.domain.program.dto.ProgramSearchRes;
 import com.festival.domain.program.service.vo.ProgramSearchCond;
 
 import java.util.List;
 
 public interface ProgramRepositoryCustom {
     ProgramPageRes getList(ProgramSearchCond programSearchCond);
+    List<ProgramSearchRes> searchProgramList(String keyword);
 }

--- a/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
+++ b/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
@@ -1,7 +1,10 @@
-package com.festival.domain.program.repository;
+package com.festival.domain.program.repository.impl;
 
 import com.festival.domain.program.dto.ProgramPageRes;
+import com.festival.domain.program.dto.ProgramSearchRes;
+import com.festival.domain.program.dto.QProgramSearchRes;
 import com.festival.domain.program.model.Program;
+import com.festival.domain.program.repository.ProgramRepositoryCustom;
 import com.festival.domain.program.service.vo.ProgramSearchCond;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -54,4 +57,27 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
         Page<Program> page = PageableExecutionUtils.getPage(result, programSearchCond.getPageable(), countQuery::fetchOne);
         return ProgramPageRes.of(page);
     }
+
+    @Override
+    public List<ProgramSearchRes> searchProgramList(String keyword) {
+        return queryFactory
+                .select(new QProgramSearchRes(
+                        program.id,
+                        program.title,
+                        program.subTitle,
+                        program.status.stringValue(),
+                        program.image.mainFilePath
+                ))
+                .from(program)
+                .where(
+                        keywordEqTitleOrSubTitle(keyword)
+                )
+                .fetch();
+    }
+
+    private static BooleanExpression keywordEqTitleOrSubTitle(String keyword) {
+        return program.title.contains(keyword)
+                .or(program.subTitle.contains(keyword));
+    }
+
 }

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -9,10 +9,7 @@ import com.festival.common.redis.RedisService;
 import com.festival.common.util.SecurityUtils;
 import com.festival.domain.image.service.ImageService;
 import com.festival.domain.member.service.MemberService;
-import com.festival.domain.program.dto.ProgramListReq;
-import com.festival.domain.program.dto.ProgramPageRes;
-import com.festival.domain.program.dto.ProgramReq;
-import com.festival.domain.program.dto.ProgramRes;
+import com.festival.domain.program.dto.*;
 import com.festival.domain.program.model.Program;
 import com.festival.domain.program.repository.ProgramRepository;
 import com.festival.domain.program.service.vo.ProgramSearchCond;
@@ -21,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.festival.common.exception.ErrorCode.*;
@@ -84,6 +82,10 @@ public class ProgramService {
                 .pageable(pageable)
                 .build()
         );
+    }
+
+    public List<ProgramSearchRes> searchProgramList(String keyword) {
+        return programRepository.searchProgramList(keyword);
     }
 
     @Transactional


### PR DESCRIPTION
# Issue
- #182 

## Issue 내용
- 축제부스와 프로그램에 대한 검색 기능을 추가하였습니다.
- 현재는 데이터의 양이 많지 않기 때문에 우선은 Like 검색 쿼리로 검색을 하도록 구현하였습니다.
- 이후 데이터양이 많이지게 된다면 리팩토링, 개선할 생각입니다.