### PR TITLE
[#191] 상황별 테스트 일괄 통과를 위한 내장 Redis 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // redis
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis', version: '2.4.10'
 
+    // Embedded Redis
+    testImplementation ('it.ozimov:embedded-redis:0.7.2') { exclude group: "org.slf4j", module: "slf4j-simple" }
+
 }
 
 tasks.named('test') {

--- a/src/test/java/com/festival/domain/util/TestRedisConfig.java
+++ b/src/test/java/com/festival/domain/util/TestRedisConfig.java
@@ -1,0 +1,46 @@
+package com.festival.domain.util;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.net.ServerSocket;
+
+@Configuration
+@Profile("test")
+public class TestRedisConfig {
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer = new RedisServer(findAvailablePort());
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        redisServer.stop();
+    }
+
+    private int findAvailablePort() {
+        for (int port = 10000; port <= 65535; port++) {
+            if (isPortAvailable(port)) {
+                return port;
+            }
+        }
+        throw new IllegalStateException("Could not find an available port in the range 10000 to 65535");
+    }
+
+    private boolean isPortAvailable(int port) {
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            serverSocket.setReuseAddress(true);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
# Issue
- #191 

# Issue 내용
- 서버에 어플리케이션을 배포하게되면 레디스가 추가된 통합 및 단위 테스트는 레디스를 열결하지 못해 local에서 성공하던 케이스들이 실패하게 됩니다.
- 따라서 테스트 상황시에만 사용할 내장 Redis를 연동하여 어디서든 케이스들이 성공할 수 있도록 의존성을 수정하였습니다.