### PR TITLE
[#233] 스냅샷 버전 동기화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 group = 'com'
-version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
@@ -72,6 +71,18 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def getYmlVersion() {
+    def ymlFile = file('src/main/resources/application.yml')
+    def versionLine = ymlFile.text.split('\n').find { it.startsWith('version: ') }
+    return versionLine ? versionLine.split(' ')[1] : '0.0.1'
+}
+
+version = getYmlVersion() + '-SNAPSHOT'
+
+jar {
+    enabled = false
 }
 
 tasks.register('updateVersion') {


### PR DESCRIPTION
# Issue
- #233 

## Issue 내용
- build시에 생성되는 jar 파일이 0.0.1로 고정되는 문제가 있었습니다.
- yml의 버전과 연동되도록 수정하였습니다.
- 도커파일에서 잘못된 jar 파일 접근을 방지하기 위해
- plain.jar파일의 생성을 false로 수정하였습니다.