### PR TITLE
[#244] Member 도메인 통합 테스트 로직 구현

### DIFF
--- a/src/main/java/com/festival/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/festival/common/security/config/SecurityConfig.java
@@ -5,8 +5,6 @@ import com.festival.common.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/src/main/java/com/festival/common/security/dto/MemberLoginReq.java
+++ b/src/main/java/com/festival/common/security/dto/MemberLoginReq.java
@@ -1,17 +1,20 @@
 package com.festival.common.security.dto;
 
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
+@NoArgsConstructor
 public class MemberLoginReq {
 
     private String username;
     private String password;
 
-    public MemberLoginReq(String username, String password) {
+    @Builder
+    private MemberLoginReq(String username, String password) {
         this.username = username;
         this.password = password;
     }

--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -17,13 +17,13 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/api/v2/booth")
+@RequestMapping("/api/v2/booth")
 public class BoothController {
 
     private final BoothService boothService;
     private final ValidationUtils validationUtils;
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<Long> createBooth(@Valid BoothReq boothReq) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -31,14 +31,14 @@ public class BoothController {
         return ResponseEntity.ok().body(boothService.createBooth(boothReq));
     }
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @PutMapping(value = "/{boothId}", consumes = "multipart/form-data")
     public ResponseEntity<Long> updateBooth(@Valid BoothReq boothReq, @PathVariable("boothId") Long id) {
         validationUtils.isBoothValid(boothReq);
         return ResponseEntity.ok().body(boothService.updateBooth(boothReq, id));
     }
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @DeleteMapping("/{boothId}")
     public ResponseEntity<Void> deleteBooth(@PathVariable("boothId") Long id) {
         boothService.deleteBooth(id);

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -8,25 +8,27 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/v2/member", produces = "application/json", consumes = "multipart/form-data")
+@RequestMapping("/api/v2/member")
 public class MemberController {
 
     private final MemberService memberService;
 
     @PreAuthorize("isAnonymous()")
     @PostMapping("/join")
-    public ResponseEntity<Void> join(@Valid MemberJoinReq memberJoinReq) {
+    public ResponseEntity<Void> joinMember(@Valid MemberJoinReq memberJoinReq) {
         memberService.join(memberJoinReq);
         return ResponseEntity.ok().build();
     }
 
     @PreAuthorize("isAnonymous()")
     @PostMapping("/login")
-    public ResponseEntity<JwtTokenRes> login(@Valid MemberLoginReq loginReq) {
+    public ResponseEntity<JwtTokenRes> loginMember(@Valid MemberLoginReq loginReq) {
         return ResponseEntity.ok().body(memberService.login(loginReq));
     }
 }

--- a/src/main/java/com/festival/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/festival/domain/program/controller/ProgramController.java
@@ -15,27 +15,27 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/v2/program")
+@RequestMapping("/api/v2/program")
 public class ProgramController {
 
     private final ProgramService programService;
     private final ValidationUtils validationUtils;
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<Long> createProgram(@Valid ProgramReq programReqDto) {
         validationUtils.isProgramValid(programReqDto);
         return ResponseEntity.ok().body(programService.createProgram(programReqDto));
     }
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @PutMapping(value = "/{programId}", consumes = "multipart/form-data")
     public ResponseEntity<Long> updateProgram(@PathVariable Long programId, @Valid ProgramReq programReqDto) {
         validationUtils.isProgramValid(programReqDto);
         return ResponseEntity.ok().body(programService.updateProgram(programId, programReqDto));
     }
 
-    @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
     @DeleteMapping("/{programId}")
     public ResponseEntity<Void> deleteProgram(@PathVariable Long programId) {
         programService.deleteProgram(programId);

--- a/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
+++ b/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
@@ -29,7 +29,7 @@ public class TimeTableController {
     }
 
     @PreAuthorize("hasRole({'ADMIN'})")
-    @PutMapping(value = "/{timeTableId}")
+    @PutMapping("/{timeTableId}")
     public ResponseEntity<Long> updateTimeTable(@PathVariable Long timeTableId,
                                                 @Valid TimeTableReq timeTableReq) {
         validationUtils.isTimeTableValid(timeTableReq);

--- a/src/test/java/com/festival/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/festival/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,113 @@
+package com.festival.domain.member.controller;
+
+import com.festival.common.security.dto.JwtTokenRes;
+import com.festival.common.security.dto.MemberLoginReq;
+import com.festival.domain.member.dto.MemberJoinReq;
+import com.festival.domain.member.model.Member;
+import com.festival.domain.member.model.MemberRole;
+import com.festival.domain.member.service.MemberService;
+import com.festival.domain.util.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MemberService memberService;
+
+    @DisplayName("유저는 회원가입을 할 수 있다.")
+    @Test
+    void joinMember() throws Exception {
+        //given
+        MemberJoinReq memberJoinReq = MemberJoinReq.builder()
+                .username("test")
+                .password("test")
+                .memberRole("ADMIN")
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v2/member/join")
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("username", memberJoinReq.getUsername())
+                        .param("password", memberJoinReq.getPassword())
+                        .param("memberRole", memberJoinReq.getMemberRole()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("이미 가입된 id는 회원가입을 할 수 없다.")
+    @Test
+    void createMemberWithSameID() throws Exception {
+        //given
+        Member member = Member.builder()
+                .username("test")
+                .password("test")
+                .memberRole(MemberRole.ADMIN)
+                .build();
+        memberRepository.saveAndFlush(member);
+
+        MemberJoinReq memberJoinReq = MemberJoinReq.builder()
+                .username("test")
+                .password("test")
+                .memberRole("ADMIN")
+                .build();
+
+        //when //then
+        MvcResult mvcResult = mockMvc.perform(post("/api/v2/member/join")
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("username", memberJoinReq.getUsername())
+                        .param("password", memberJoinReq.getPassword())
+                        .param("memberRole", memberJoinReq.getMemberRole())
+                )
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andReturn();
+    }
+
+    @DisplayName("회원가입한 사용자는 로그인을 할 수 있다.")
+    @Test
+    void loginMember() throws Exception {
+        //given
+        MemberJoinReq memberJoinReq = MemberJoinReq.builder()
+                .username("test")
+                .password("test")
+                .memberRole("ADMIN")
+                .build();
+        memberService.join(memberJoinReq);
+
+        MemberLoginReq loginReq = MemberLoginReq.builder()
+                .username("test")
+                .password("test")
+                .build();
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(post("/api/v2/member/login")
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .param("username", loginReq.getUsername())
+                        .param("password", loginReq.getPassword())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String result = mvcResult.getResponse().getContentAsString();
+        JwtTokenRes jwtTokenRes = objectMapper.readValue(result, JwtTokenRes.class);
+        assertThat(jwtTokenRes).isNotNull();
+        assertThat(jwtTokenRes.getAccessToken()).isNotNull();
+        assertThat(jwtTokenRes.getRefreshToken()).isNotNull();
+        assertThat(jwtTokenRes.getTokenType()).isEqualTo("Bearer");
+    }
+}

--- a/src/test/java/com/festival/domain/util/TestRedisConfig.java
+++ b/src/test/java/com/festival/domain/util/TestRedisConfig.java
@@ -15,7 +15,6 @@ public class TestRedisConfig {
 
     private RedisServer redisServer;
 
-
     @Value("${custom.redis.port}")
     private int redisPort;
 


### PR DESCRIPTION
# Issue
- #244 

## Issue 내용
- Member 통합 테스트 로직을 구현했습니다.
- Member dto에 setter를 추가하였습니다.

## 부가사항
- 각 클래스 별 띄어쓰기, 미사용 의존성 제거를 수행했습니다.