### PR TITLE
[#290] API contentType 통합

### DIFF
--- a/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
+++ b/src/main/java/com/festival/domain/bambooforest/controller/BambooForestController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class BambooForestController {
 
     @PreAuthorize("permitAll()")
     @Operation(summary = "대나무숲 글 등록")
-    @PostMapping(produces = APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> createBamBooForest(@Valid BamBooForestReq bamBooForestReq) {
         validationUtils.isBamBooForestValid(bamBooForestReq);
         return ResponseEntity.ok().body(bambooForestService.createBamBooForest(bamBooForestReq));
@@ -41,7 +42,7 @@ public class BambooForestController {
     }
 
     @PreAuthorize("permitAll()")
-    @Operation(summary = "대나무숲 목록 조회", description = "파라미터로 입력하셔야 합니다.!")
+    @Operation(summary = "대나무숲 목록 조회")
     @GetMapping(value = "/list", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<BamBooForestPageRes> getBamBooForestList(@Valid @ParameterObject BamBooForestListReq bamBooForestListReq) {
         return ResponseEntity.ok().body(bambooForestService.getBamBooForestList(PageRequest.of(bamBooForestListReq.getPage(), bamBooForestListReq.getSize())));

--- a/src/main/java/com/festival/domain/bambooforest/repository/impl/BamBooForestRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/bambooforest/repository/impl/BamBooForestRepositoryImpl.java
@@ -29,6 +29,7 @@ public class BamBooForestRepositoryImpl implements BamBooForestRepositoryCustom 
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .where(bamBooForest.deleted.eq(false))
+                .orderBy(bamBooForest.id.desc())
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory

--- a/src/main/java/com/festival/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/festival/domain/booth/controller/BoothController.java
@@ -29,7 +29,7 @@ public class BoothController {
     private final ValidationUtils validationUtils;
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
-    @Operation(summary = "부스 등록")
+    @Operation(summary = "부스 등록", description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
     @PostMapping(produces = APPLICATION_JSON_VALUE, consumes = MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Long> createBooth(@Valid @ParameterObject BoothReq boothReq) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -38,7 +38,7 @@ public class BoothController {
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
-    @Operation(summary = "부스 업데이트(전체)")
+    @Operation(summary = "부스 업데이트(전체)", description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
     @PutMapping(value = "/{boothId}", produces = APPLICATION_JSON_VALUE, consumes = MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Long> updateBooth(@Valid @ParameterObject BoothReq boothReq, @PathVariable("boothId") Long id) {
         validationUtils.isBoothValid(boothReq);

--- a/src/main/java/com/festival/domain/guide/controller/GuideController.java
+++ b/src/main/java/com/festival/domain/guide/controller/GuideController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class GuideController {
 
     @PreAuthorize("hasRole({'ADMIN'})")
     @Operation(summary = "안내사항 등록")
-    @PostMapping(produces = APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE ,produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> createGuide(@Valid GuideReq guideReq) {
         validationUtils.isGuideValid(guideReq);
         return ResponseEntity.ok().body(guideService.createGuide(guideReq));
@@ -35,7 +36,7 @@ public class GuideController {
 
     @PreAuthorize("hasRole({'ADMIN'})")
     @Operation(summary = "안내사항 수정")
-    @PutMapping(value = "/{guideId}", produces = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{guideId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> updateGuide(@PathVariable("guideId") Long guideId, @Valid GuideReq guideReq) {
         validationUtils.isGuideValid(guideReq);
         return ResponseEntity.ok().body(guideService.updateGuide(guideId, guideReq));
@@ -58,8 +59,8 @@ public class GuideController {
 
     @PreAuthorize("permitAll()")
     @Operation(summary = "안내사항 목록 조회!")
-    @GetMapping(value = "/list", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<GuidePageRes> getGuideList(@Valid @ParameterObject GuideListReq guideListReq) {
+    @GetMapping(value = "/list", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<GuidePageRes> getGuideList(@Valid GuideListReq guideListReq) {
         return ResponseEntity.ok().body(guideService.getGuideList(guideListReq));
     }
 

--- a/src/main/java/com/festival/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/festival/domain/program/controller/ProgramController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -27,16 +28,16 @@ public class ProgramController {
     private final ValidationUtils validationUtils;
 
     @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
-    @Operation(summary = "프로그램 등록")
-    @PostMapping(produces = APPLICATION_JSON_VALUE, consumes = MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로그램 등록", description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE ,produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> createProgram(@Valid @ParameterObject ProgramReq programReq) {
         validationUtils.isProgramValid(programReq);
         return ResponseEntity.ok().body(programService.createProgram(programReq, LocalDate.now()));
     }
 
     @PreAuthorize("hasRole('ADMIN') or  hasRole('MANAGER')")
-    @Operation(summary = "프로그램 업데이트(전체) ")
-    @PutMapping(value = "/{programId}", produces = APPLICATION_JSON_VALUE, consumes = MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로그램 업데이트(전체) ",  description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
+    @PutMapping(value = "/{programId}", consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> updateProgram(@PathVariable("programId") Long programId, @Valid @ParameterObject ProgramReq programReq) {
         validationUtils.isProgramValid(programReq);
         return ResponseEntity.ok().body(programService.updateProgram(programId, programReq));
@@ -67,7 +68,7 @@ public class ProgramController {
     @Operation(summary = "프로그램 목록 조회")
     @PreAuthorize("permitAll()")
     @GetMapping(value = "/list", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<ProgramPageRes> getProgramList(@Valid ProgramListReq programListReq) {
+    public ResponseEntity<ProgramPageRes> getProgramList(@Valid @ParameterObject ProgramListReq programListReq) {
         return ResponseEntity.ok().body(programService.getProgramList(programListReq));
     }
 

--- a/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
+++ b/src/main/java/com/festival/domain/timetable/controller/TimeTableController.java
@@ -27,16 +27,16 @@ public class TimeTableController {
     private final ValidationUtils validationUtils;
 
     @PreAuthorize("hasRole({'ADMIN'})")
-    @Operation(summary = "타임테이블 등록")
-    @PostMapping(produces = APPLICATION_JSON_VALUE)
+    @Operation(summary = "타임테이블 등록", description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> createTimeTable(@Valid @ParameterObject TimeTableReq timeTableReq) {
         validationUtils.isTimeTableValid(timeTableReq);
         return ResponseEntity.ok().body(timeTableService.createTimeTable(timeTableReq));
     }
 
     @PreAuthorize("hasRole({'ADMIN'})")
-    @Operation(summary = "타임테이블 수정")
-    @PutMapping(value = "/{timeTableId}", produces = APPLICATION_JSON_VALUE)
+    @Operation(summary = "타임테이블 수정", description = "MULTIPART_FORM_DATA로 보내주시면 감사하겠습니다.")
+    @PutMapping(value = "/{timeTableId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> updateTimeTable(@PathVariable("timeTableId") Long timeTableId,
                                                 @Valid @ParameterObject TimeTableReq timeTableReq) {
         validationUtils.isTimeTableValid(timeTableReq);


### PR DESCRIPTION
# Issue
- #290 

# Issue 내용
- www-encorded-formData 통신 문제로 모든 POST, PUT요청은 multipart-formData로 대체합니다.
- 추후 이미지를 제외한 데이터에 대해서는 JSON으로 받는게 좋아보입니다.
- 날짜나 타입의 포맷을 알려주기 위해 @ParmeterObject를 사용했습니다.
   -> 스웨거에서 파라미터를 받는것으로 인식하기 때문에 description에 설명을 써놔야합니다.