### PR TITLE
[#323] S3 입출력 로직 활성화

### DIFF
--- a/src/main/java/com/festival/common/util/ImageUtils.java
+++ b/src/main/java/com/festival/common/util/ImageUtils.java
@@ -36,20 +36,19 @@ public class ImageUtils {
             om.setContentLength(file.getInputStream().available());
             om.setContentType(file.getContentType());
 
-            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, folderName + fileName, file.getInputStream(), om);
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, folderName + "/" + fileName, file.getInputStream(), om);
             // 객체의 권한을 공개로 설정(버킷에서 확인 가능)
             putObjectRequest.withCannedAcl(CannedAccessControlList.PublicRead);
             // 파일 업로드
             amazonS3.putObject(putObjectRequest);
             return fileName;
         } catch (AmazonS3Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } catch(SdkClientException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return null;
     }
 
     public List<String> uploadMulti(List<MultipartFile> files, String kind) {
@@ -63,7 +62,7 @@ public class ImageUtils {
         return kind + "_" + UUID.randomUUID() + ext;
     }
 
-    public void deleteFile(Image image){
+    public void deleteFiles(Image image){
         DeleteObjectRequest deleteObjectRequest;
         if (image.getMainFilePath() != null) {
             deleteObjectRequest = new DeleteObjectRequest(bucketName, image.getMainFilePath());

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -37,7 +37,7 @@ public class BoothService {
 
     public Long createBooth(BoothReq boothReq) {
         Booth booth = Booth.of(boothReq);
-        booth.setImage(imageService.createImage(boothReq.getMainFile(), boothReq.getSubFiles(), boothReq.getType()));
+        booth.setImage(imageService.uploadImage(boothReq.getMainFile(), boothReq.getSubFiles(), boothReq.getType()));
         booth.connectMember(memberService.getAuthenticationMember());
         return boothRepository.save(booth).getId();
     }
@@ -49,12 +49,9 @@ public class BoothService {
             throw new ForbiddenException(FORBIDDEN_UPDATE);
         }
 
-        /**
-         * @Todo
-         *  delete로직 작성해야함
-         */
+        imageService.deleteImage(booth.getImage());
+        booth.setImage(imageService.uploadImage(boothReq.getMainFile(), boothReq.getSubFiles(), boothReq.getType()));
         booth.update(boothReq);
-        booth.setImage(imageService.createImage(boothReq.getMainFile(), boothReq.getSubFiles(), boothReq.getType()));
         return id;
     }
 

--- a/src/main/java/com/festival/domain/image/service/ImageService.java
+++ b/src/main/java/com/festival/domain/image/service/ImageService.java
@@ -3,6 +3,7 @@ package com.festival.domain.image.service;
 import com.festival.common.util.ImageUtils;
 import com.festival.domain.image.model.Image;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,19 +16,23 @@ public class ImageService {
 
     private final ImageUtils imageUtils;
 
+    @Value("${cloud.aws.endpoint}/${cloud.aws.bucketName}/${cloud.aws.folderName}/")
+    private String fullEndpoint;
+
     /**
      * @Description
      * 실제 S3와 연동되는 API입니다.
-
+    */
     public Image uploadImage(MultipartFile mainFile, List<MultipartFile> subFiles, String kind){
         String mainFilePath = imageUtils.upload(mainFile, kind);
         List<String> subFilePaths = imageUtils.uploadMulti(subFiles,kind);
 
         return Image.builder()
-                .mainFilePath(mainFilePath)
-                .subFilePaths(subFilePaths).build();
+                .mainFilePath(fullEndpoint + mainFilePath)
+                .subFilePaths(subFilePaths.stream()
+                        .map(s -> fullEndpoint + s)
+                        .collect(Collectors.toList())).build();
     }
-     */
 
     /**
      * @Description
@@ -61,6 +66,6 @@ public class ImageService {
     }
 
     public void deleteImage(Image image) {
-        imageUtils.deleteFile(image);
+        imageUtils.deleteFiles(image);
     }
 }

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -38,7 +38,7 @@ public class ProgramService {
     @Transactional
     public Long createProgram(ProgramReq programReq, LocalDate dateTime) {
         Program program = Program.of(programReq, dateTime);
-        program.setImage(imageService.createImage(programReq.getMainFile(), programReq.getSubFiles(), programReq.getType()));
+        program.setImage(imageService.uploadImage(programReq.getMainFile(), programReq.getSubFiles(), programReq.getType()));
         program.connectMember(memberService.getAuthenticationMember());
         return programRepository.save(program).getId();
     }
@@ -51,7 +51,8 @@ public class ProgramService {
             throw new ForbiddenException(FORBIDDEN_UPDATE);
         }
 
-        program.setImage(imageService.createImage(programReq.getMainFile(), programReq.getSubFiles(), programReq.getType()));
+        imageService.deleteImage(program.getImage());
+        program.setImage(imageService.uploadImage(programReq.getMainFile(), programReq.getSubFiles(), programReq.getType()));
         program.update(programReq);
         return program.getId();
     }


### PR DESCRIPTION
# Issue
- #323 

# Issue 내용
- S3 입출력 로직을 활성화 합니다.
- 기본 이미지 주소가 파일이름으로만 저장되었습니다.
- 주소인만큼 전체 엔드포인트를 포함하여 저장되도록 수정하였습니다.

**imageName -> endpoint/bucketName/folderName/imageName**