### PR TITLE
[#325] jwtToken에 대한 예외처리 작성.

### DIFF
--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -7,8 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400
+    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TYPE_ACCESS_TOKEN("AccessToken의 타입은 Bearer입니다.", HttpStatus.BAD_REQUEST),
+    EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED("이미 삭제된 글입니다.", HttpStatus.BAD_REQUEST),
-
     INVALID_TYPE("입력된 값의 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_LENGTH("입력된 값의 길이가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_RANGE("입력된 값의 범위가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.festival.common.security;
 
+import com.festival.common.exception.ErrorCode;
+import com.festival.common.exception.custom_exception.BadRequestException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -19,11 +21,23 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        String token = extractBearerToken((HttpServletRequest) request);
+
+        if (token!= null && jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(request, response);
+    }
+
+    /**
+     * @Description
+     * 토큰의 유무와 Bearer토큰의 여부에 대해 검증한 뒤 토큰을 반환합니다.
+     */
+    private String extractBearerToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if(!bearerToken.startsWith("Bearer"))
+            throw new BadRequestException(ErrorCode.INVALID_TYPE_ACCESS_TOKEN);
+        return bearerToken.split(" ")[1].trim();
     }
 }

--- a/src/main/java/com/festival/common/security/dto/JwtTokenRes.java
+++ b/src/main/java/com/festival/common/security/dto/JwtTokenRes.java
@@ -9,11 +9,9 @@ public class JwtTokenRes {
 
     private String tokenType;
     private String accessToken;
-    private String refreshToken;
 
-    public JwtTokenRes(String tokenType, String accessToken, String refreshToken) {
+    public JwtTokenRes(String tokenType, String accessToken) {
         this.tokenType = tokenType;
         this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
     }
 }


### PR DESCRIPTION
# Issue
- #325 

# Issue 내용
- jwt 인증에 대한 예외처리 로직을 작성했습니다
    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.BAD_REQUEST),
    INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.BAD_REQUEST),
    INVALID_TYPE_ACCESS_TOKEN("AccessToken의 타입은 Bearer입니다.", HttpStatus.BAD_REQUEST),
    EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.BAD_REQUEST),
- resolveToken보다는 Bearer인지 타입만 검증한 뒤 추출하는 코드이기에 extractBearerToken 으로 변경했습니다.
    
