### PR TITLE
[#331] RefreshToken 도입( 발급, 재발급)

### DIFF
--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400
+    EMPTY_REFRESH_TOKEN("RefreshToken이 필요합니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED("이미 삭제된 글입니다.", HttpStatus.BAD_REQUEST),
     INVALID_TYPE("입력된 값의 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_LENGTH("입력된 값의 길이가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -7,10 +7,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400
-    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.BAD_REQUEST),
-    INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_TYPE_ACCESS_TOKEN("AccessToken의 타입은 Bearer입니다.", HttpStatus.BAD_REQUEST),
-    EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED("이미 삭제된 글입니다.", HttpStatus.BAD_REQUEST),
     INVALID_TYPE("입력된 값의 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_LENGTH("입력된 값의 길이가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
@@ -18,6 +14,14 @@ public enum ErrorCode {
     INVALID_STATUS("입력된 값의 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_DATE("입력된 값의 날짜 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_EMAIL("입력된 값의 이메일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // 401
+    INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_PERIOD_REFRESH_TOKEN("기한이 만료된 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
+    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("유효하지 않은 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
 
     // 404
     NOT_FOUND_BOOTH("부스가 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
@@ -2,45 +2,41 @@ package com.festival.common.security;
 
 import com.festival.common.exception.ErrorCode;
 import com.festival.common.exception.custom_exception.BadRequestException;
+import com.festival.common.util.JwtTokenUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.net.http.HttpHeaders;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String token = extractBearerToken((HttpServletRequest) request);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = JwtTokenUtils.extractBearerToken(request.getHeader("accessToken"));
 
-        if (token!= null && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        if(!request.getRequestURI().equals("/api/v2/member/rotate") && accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
+            if (jwtTokenProvider.validateToken(accessToken)) { // 토큰이 유효한 경우
+                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
     }
 
-    /**
-     * @Description
-     * Bearer토큰의 여부에 대해 검증한 뒤 토큰을 반환합니다.
-     */
-    private String extractBearerToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if(bearerToken != null){
-            if(!bearerToken.startsWith("Bearer"))
-                throw new BadRequestException(ErrorCode.INVALID_TYPE_ACCESS_TOKEN);
-            return bearerToken.split(" ")[1].trim();
-        }
-        return null;
-    }
+
+
+
 }

--- a/src/main/java/com/festival/common/security/dto/JwtTokenRes.java
+++ b/src/main/java/com/festival/common/security/dto/JwtTokenRes.java
@@ -9,9 +9,11 @@ public class JwtTokenRes {
 
     private String tokenType;
     private String accessToken;
+    private String refreshToken;
 
-    public JwtTokenRes(String tokenType, String accessToken) {
+    public JwtTokenRes(String tokenType, String accessToken, String refreshToken) {
         this.tokenType = tokenType;
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/festival/common/util/JwtTokenUtils.java
+++ b/src/main/java/com/festival/common/util/JwtTokenUtils.java
@@ -1,0 +1,23 @@
+package com.festival.common.util;
+
+import com.festival.common.exception.ErrorCode;
+import com.festival.common.exception.custom_exception.BadRequestException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenUtils {
+    /**
+     * @Description
+     * Bearer토큰의 여부에 대해 검증한 뒤 토큰을 반환합니다.
+     */
+    public static String extractBearerToken(String token) {
+        if(token != null){
+            if(!token.startsWith("Bearer"))
+                throw new BadRequestException(ErrorCode.INVALID_TYPE_TOKEN);
+            return token.split(" ")[1].trim();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/festival/common/util/SecurityUtils.java
+++ b/src/main/java/com/festival/common/util/SecurityUtils.java
@@ -2,9 +2,11 @@ package com.festival.common.util;
 
 import com.festival.domain.member.model.Member;
 import com.festival.domain.member.model.MemberRole;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Component
 public class SecurityUtils {
 
     public static boolean checkingRole(Member owner, Member accessMember) {

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -1,15 +1,20 @@
 package com.festival.domain.member.controller;
 
+import com.festival.common.exception.ErrorCode;
+import com.festival.common.exception.custom_exception.BadRequestException;
 import com.festival.common.security.dto.JwtTokenRes;
 import com.festival.common.security.dto.MemberLoginReq;
+import com.festival.common.util.JwtTokenUtils;
 import com.festival.domain.member.dto.MemberJoinReq;
 import com.festival.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,4 +40,15 @@ public class MemberController {
     public ResponseEntity<JwtTokenRes> loginMember(@Valid MemberLoginReq loginReq) {
         return ResponseEntity.ok().body(memberService.login(loginReq));
     }
+
+    @GetMapping("/rotate")
+    public JwtTokenRes rotateToken(HttpServletRequest request){
+        String refreshToken = JwtTokenUtils.extractBearerToken(request.getHeader("refreshToken"));
+        if(refreshToken.isBlank())
+            throw new BadRequestException(ErrorCode.EMPTY_REFRESH_TOKEN);
+
+        return memberService.rotateToken(refreshToken);
+    }
+
+
 }

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -46,8 +46,7 @@ public class MemberService {
 
     public JwtTokenRes login(MemberLoginReq loginReq) {
         Authentication authenticate = attemptAuthenticate(loginReq);
-        List<String> roles = settingStringRoles(loginReq.getUsername());
-        return jwtTokenProvider.createJwtToken(authenticate, roles);
+        return jwtTokenProvider.createJwtToken(authenticate);
     }
 
     public Member getAuthenticationMember() {
@@ -58,17 +57,16 @@ public class MemberService {
     private boolean isLoginIdSave(String email) {
         return memberRepository.existsByUsername(email);
     }
-
-    private List<String> settingStringRoles(String loginId) {
-        Member member = memberRepository.findByUsername(loginId).orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
-        return member.getMemberRoles().stream().map(MemberRole::getValue).collect(Collectors.toList());
-    }
-
     private Authentication attemptAuthenticate(MemberLoginReq loginReq) {
         return authenticationManagerBuilder.getObject().authenticate(createAuthenticationToken(loginReq));
     }
 
     private static UsernamePasswordAuthenticationToken createAuthenticationToken(MemberLoginReq loginReq) {
         return new UsernamePasswordAuthenticationToken(loginReq.getUsername(), loginReq.getPassword());
+    }
+
+    public JwtTokenRes rotateToken(String refreshToken) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+        return jwtTokenProvider.createJwtToken(authentication);
     }
 }

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
     public JwtTokenRes login(MemberLoginReq loginReq) {
         Authentication authenticate = attemptAuthenticate(loginReq);
         List<String> roles = settingStringRoles(loginReq.getUsername());
-        return jwtTokenProvider.createToken(authenticate, roles);
+        return jwtTokenProvider.createJwtToken(authenticate, roles);
     }
 
     public Member getAuthenticationMember() {


### PR DESCRIPTION
# Issue
- #331 

# Issue 내용
- 로그인 시 AccessToken과 RefreshToken을 동시에 발급합니다.
- AccessToken이 만료 됐을 시 토큰 재발급 요청(api/v2/member/rotate)을 통해 AccessToken과 RefreshToken을 재발급 받습니다.
  -> 요청 URI는 조금 더 고민해볼 생각입니다.
- 토큰을 생성할 때 List<String> roles를 넘겨서 처리하던 방식에서 Authentication만 넘기고 authorities를 꺼내서 권한 정보를 만드는 방식으로 리팩토링 했습니다.
- 현재 토큰 발급과 재발급 기능만 구현한 상황이며, 다음 작업에서 Redis를 이용해 칩입 탐지 기능을 구현할 예정입니다.
   
