### PR TITLE
[#335] Redis를 이용해 토큰 탈취를 감지

### DIFF
--- a/src/main/java/com/festival/common/redis/RedisConfig.java
+++ b/src/main/java/com/festival/common/redis/RedisConfig.java
@@ -32,11 +32,12 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Long> redisTemplate() {
-        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -31,13 +31,13 @@ public class RedisService {
     }
 
     public boolean isDuplicateAccess(String ipAddress, String domainName) {
-        if(getData(ipAddress + "_" + domainName) == null) {
-            setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
-            return true;
-        }
-        return false;
+        if(getData(ipAddress + "_" + domainName) == null)
+            return false;
+        return true;
     }
-
+    public void setDuplicateAccess(String ipAddress, String domainName){
+        setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
+    }
     public Set<String> getKeySet(String domain) {
         return redisTemplate.keys(domain);
     }

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -2,6 +2,7 @@ package com.festival.common.redis;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +12,10 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @Service
 public class RedisService {
+    @Value("${custom.jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
 
-    private final RedisTemplate<String, Long> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @PostConstruct
     public void initialize() {
@@ -26,8 +29,8 @@ public class RedisService {
         redisTemplate.opsForValue().increment(key);
     }
 
-    public void decreaseRedisViewCount(String key) {
-        redisTemplate.opsForValue().decrement(key);
+    public void setRefreshToken(String username, String refreshToken){
+        setData(username, refreshToken, refreshExpirationTime, TimeUnit.SECONDS);
     }
 
     public boolean isDuplicateAccess(String ipAddress, String domainName) {
@@ -36,7 +39,7 @@ public class RedisService {
         return true;
     }
     public void setDuplicateAccess(String ipAddress, String domainName){
-        setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
+        setData(ipAddress + "_" + domainName, 1L, 1L, TimeUnit.DAYS);
     }
     public Set<String> getKeySet(String domain) {
         return redisTemplate.keys(domain);
@@ -46,11 +49,15 @@ public class RedisService {
         redisTemplate.delete(key);
     }
 
-    private void setData(String key, Long value, TimeUnit timeUnit) {
-        redisTemplate.opsForValue().set(key, value, 1L, timeUnit);
+    private void setData(String key, Object value, Long time,TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);
     }
 
-    public Long getData(String key) {
+    public Object getData(String key) {
         return redisTemplate.opsForValue().get(key);
+    }
+
+    public void rotateRefreshToken(String name, String refreshToken) {
+        setRefreshToken(name, refreshToken);
     }
 }

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -22,7 +22,7 @@ public class SchedulerRunner {
     private final BoothService boothService;
     private final ProgramService programService;
 
-    @Scheduled(fixedDelay = 3600000)
+    @Scheduled(fixedDelay = 1000)
     public void updateViewCount()
     {
         Set<String> keySet = redisService.getKeySet("*Id*");

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -22,7 +22,11 @@ public class SchedulerRunner {
     private final BoothService boothService;
     private final ProgramService programService;
 
-    @Scheduled(fixedDelay = 1000)
+    /**
+     * @Description
+     * 설정한 업데이트 주기에 따라 Redis에 쌓여있던 조회수를 RDB에 한번에 반영합니다.
+     */
+    @Scheduled(fixedDelay = 3600000)
     public void updateViewCount()
     {
         Set<String> keySet = redisService.getKeySet("*Id*");
@@ -30,21 +34,25 @@ public class SchedulerRunner {
             String[] splitKey = key.split("_");
             switch (splitKey[0]) {
                 case "Booth" -> {
-                    boothService.increaseBoothViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    boothService.increaseBoothViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Guide" -> {
-                    guideService.increaseGuideViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    guideService.increaseGuideViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Program" -> {
-                    programService.increaseProgramViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    programService.increaseProgramViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
             }
         }
     }
 
+    /**
+     * @Description
+     * 하루마다 운영상태를 전환합니다.
+     */
     @Scheduled(cron = "0 0 0 * * *")
     public void updateOperateStatus() {
         programService.settingProgramStatus();

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -69,10 +69,9 @@ public class BoothService {
         Booth booth = checkingDeletedStatus(boothRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
             redisService.increaseRedisViewCount("Booth_Id_" + booth.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Booth_" + booth.getId());
         }
+
 
         return BoothRes.of(booth);
     }

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -67,9 +67,13 @@ public class BoothService {
 
     public BoothRes getBooth(Long id, String ipAddress) {
         Booth booth = checkingDeletedStatus(boothRepository.findById(id));
-        if(redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
             redisService.increaseRedisViewCount("Booth_Id_" + booth.getId());
         }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Booth_" + booth.getId());
+        }
+
         return BoothRes.of(booth);
     }
 

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -63,8 +63,11 @@ public class GuideService {
 
     public GuideRes getGuide(Long id, String ipAddress){
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
-        if(redisService.isDuplicateAccess(ipAddress, "Guide" + guide.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Guide_" + guide.getId())) {
             redisService.increaseRedisViewCount("Guide_Id_" + guide.getId());
+        }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Guide_" + guide.getId());
         }
         return GuideRes.of(guide);
     }

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -65,10 +65,9 @@ public class GuideService {
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Guide_" + guide.getId())) {
             redisService.increaseRedisViewCount("Guide_Id_" + guide.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Guide_" + guide.getId());
         }
+
         return GuideRes.of(guide);
     }
 

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -94,8 +94,6 @@ public class ProgramService {
         Program program = checkingDeletedStatus(programRepository.findById(programId));
         if(!redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
             redisService.increaseRedisViewCount("Program_Id_" + program.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Program_" + program.getId());
         }
 

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -92,9 +92,14 @@ public class ProgramService {
 
     public ProgramRes getProgram(Long programId, String ipAddress) {
         Program program = checkingDeletedStatus(programRepository.findById(programId));
-        if(redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
             redisService.increaseRedisViewCount("Program_Id_" + program.getId());
         }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Program_" + program.getId());
+        }
+
+
         return ProgramRes.of(program);
     }
 


### PR DESCRIPTION
# Issue
- #335 

# Issue 내용
- isDuplicateAccess메서드의 논리가 반대로 설정돼있어서 수정했습니다.
  -> 추가로 중복 체크만 해야 하는 메서드에서 중복설정까지 하고있는 것 같아 역할을 분리했습니다.  

- Redis에 자신의 PK기반으로 RefreshToken을 저장합니다.
  -> 침입자가 RefreshToken을 탈취하여 기존의 RefreshToken을 갱신했다면
       사용자가 RefreshToken을 이용해 재발급을 시도할 때 침입이 탐지됩니다.
