### PR TITLE
[#339]  RefreshToken 검증 및 예외처리

### DIFF
--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_EMAIL("입력된 값의 이메일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 401
+    SNATCH_TOKEN("Refresh Token 탈취를 감지하여 로그아웃 처리됩니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_PERIOD_REFRESH_TOKEN("기한이 만료된 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/festival/common/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/festival/common/redis/EmbeddedRedisConfig.java
@@ -9,8 +9,8 @@ import redis.embedded.RedisServer;
 
 import java.net.ServerSocket;
 
-@Configuration
-@Profile("dev")
+//@Configuration
+//@Profile("dev")
 public class EmbeddedRedisConfig {
 
     private RedisServer redisServer;

--- a/src/main/java/com/festival/common/redis/RedisConfig.java
+++ b/src/main/java/com/festival/common/redis/RedisConfig.java
@@ -32,11 +32,12 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Long> redisTemplate() {
-        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -60,4 +60,8 @@ public class RedisService {
     public void rotateRefreshToken(String name, String refreshToken) {
         setRefreshToken(name, refreshToken);
     }
+
+    public void deleteRefreshToken(String name) {
+        deleteData(name);
+    }
 }

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -31,13 +31,13 @@ public class RedisService {
     }
 
     public boolean isDuplicateAccess(String ipAddress, String domainName) {
-        if(getData(ipAddress + "_" + domainName) == null) {
-            setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
-            return true;
-        }
-        return false;
+        if(getData(ipAddress + "_" + domainName) == null)
+            return false;
+        return true;
     }
-
+    public void setDuplicateAccess(String ipAddress, String domainName){
+        setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
+    }
     public Set<String> getKeySet(String domain) {
         return redisTemplate.keys(domain);
     }

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -2,6 +2,7 @@ package com.festival.common.redis;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +12,10 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @Service
 public class RedisService {
+    @Value("${custom.jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
 
-    private final RedisTemplate<String, Long> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @PostConstruct
     public void initialize() {
@@ -26,8 +29,8 @@ public class RedisService {
         redisTemplate.opsForValue().increment(key);
     }
 
-    public void decreaseRedisViewCount(String key) {
-        redisTemplate.opsForValue().decrement(key);
+    public void setRefreshToken(String username, String refreshToken){
+        setData(username, refreshToken, refreshExpirationTime, TimeUnit.SECONDS);
     }
 
     public boolean isDuplicateAccess(String ipAddress, String domainName) {
@@ -36,7 +39,7 @@ public class RedisService {
         return true;
     }
     public void setDuplicateAccess(String ipAddress, String domainName){
-        setData(ipAddress + "_" + domainName, 1L, TimeUnit.DAYS);
+        setData(ipAddress + "_" + domainName, 1L, 1L, TimeUnit.DAYS);
     }
     public Set<String> getKeySet(String domain) {
         return redisTemplate.keys(domain);
@@ -46,11 +49,15 @@ public class RedisService {
         redisTemplate.delete(key);
     }
 
-    private void setData(String key, Long value, TimeUnit timeUnit) {
-        redisTemplate.opsForValue().set(key, value, 1L, timeUnit);
+    private void setData(String key, Object value, Long time,TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);
     }
 
-    public Long getData(String key) {
+    public Object getData(String key) {
         return redisTemplate.opsForValue().get(key);
+    }
+
+    public void rotateRefreshToken(String name, String refreshToken) {
+        setRefreshToken(name, refreshToken);
     }
 }

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -22,7 +22,7 @@ public class SchedulerRunner {
     private final BoothService boothService;
     private final ProgramService programService;
 
-    @Scheduled(fixedDelay = 3600000)
+    @Scheduled(fixedDelay = 1000)
     public void updateViewCount()
     {
         Set<String> keySet = redisService.getKeySet("*Id*");

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -22,7 +22,11 @@ public class SchedulerRunner {
     private final BoothService boothService;
     private final ProgramService programService;
 
-    @Scheduled(fixedDelay = 1000)
+    /**
+     * @Description
+     * 설정한 업데이트 주기에 따라 Redis에 쌓여있던 조회수를 RDB에 한번에 반영합니다.
+     */
+    @Scheduled(fixedDelay = 3600000)
     public void updateViewCount()
     {
         Set<String> keySet = redisService.getKeySet("*Id*");
@@ -30,21 +34,25 @@ public class SchedulerRunner {
             String[] splitKey = key.split("_");
             switch (splitKey[0]) {
                 case "Booth" -> {
-                    boothService.increaseBoothViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    boothService.increaseBoothViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Guide" -> {
-                    guideService.increaseGuideViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    guideService.increaseGuideViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Program" -> {
-                    programService.increaseProgramViewCount(redisService.getData(key), Long.parseLong(splitKey[2]));
+                    programService.increaseProgramViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
             }
         }
     }
 
+    /**
+     * @Description
+     * 하루마다 운영상태를 전환합니다.
+     */
     @Scheduled(cron = "0 0 0 * * *")
     public void updateOperateStatus() {
         programService.settingProgramStatus();

--- a/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/festival/common/security/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = JwtTokenUtils.extractBearerToken(request.getHeader("accessToken"));
 
         if(!request.getRequestURI().equals("/api/v2/member/rotate") && accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
-            if (jwtTokenProvider.validateToken(accessToken)) { // 토큰이 유효한 경우
+            if (jwtTokenProvider.validateAccessToken(accessToken)) { // 토큰이 유효한 경우
                 Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/festival/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/festival/common/security/JwtTokenProvider.java
@@ -109,9 +109,9 @@ public class JwtTokenProvider {
      * @Description
      * 토큰의 만료여부와 유효성에 대해 검증합니다.
      */
-    public boolean validateToken(String jwtToken) {
+    public boolean validateAccessToken(String accessToken) {
         try {
-            parseToken(jwtToken);
+            parseToken(accessToken);
             return true;
         } catch (ExpiredJwtException e) {
             throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
@@ -119,6 +119,17 @@ public class JwtTokenProvider {
             throw new InvalidException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
     }
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            parseToken(refreshToken);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_REFRESH_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
     private Jws<Claims> parseToken(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -69,10 +69,9 @@ public class BoothService {
         Booth booth = checkingDeletedStatus(boothRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
             redisService.increaseRedisViewCount("Booth_Id_" + booth.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Booth_" + booth.getId());
         }
+
 
         return BoothRes.of(booth);
     }

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -67,9 +67,13 @@ public class BoothService {
 
     public BoothRes getBooth(Long id, String ipAddress) {
         Booth booth = checkingDeletedStatus(boothRepository.findById(id));
-        if(redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
             redisService.increaseRedisViewCount("Booth_Id_" + booth.getId());
         }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Booth_" + booth.getId());
+        }
+
         return BoothRes.of(booth);
     }
 

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -63,8 +63,11 @@ public class GuideService {
 
     public GuideRes getGuide(Long id, String ipAddress){
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
-        if(redisService.isDuplicateAccess(ipAddress, "Guide" + guide.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Guide_" + guide.getId())) {
             redisService.increaseRedisViewCount("Guide_Id_" + guide.getId());
+        }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Guide_" + guide.getId());
         }
         return GuideRes.of(guide);
     }

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -65,10 +65,9 @@ public class GuideService {
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Guide_" + guide.getId())) {
             redisService.increaseRedisViewCount("Guide_Id_" + guide.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Guide_" + guide.getId());
         }
+
         return GuideRes.of(guide);
     }
 

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -94,8 +94,6 @@ public class ProgramService {
         Program program = checkingDeletedStatus(programRepository.findById(programId));
         if(!redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
             redisService.increaseRedisViewCount("Program_Id_" + program.getId());
-        }
-        else{
             redisService.setDuplicateAccess(ipAddress, "Program_" + program.getId());
         }
 

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -92,9 +92,14 @@ public class ProgramService {
 
     public ProgramRes getProgram(Long programId, String ipAddress) {
         Program program = checkingDeletedStatus(programRepository.findById(programId));
-        if(redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
+        if(!redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
             redisService.increaseRedisViewCount("Program_Id_" + program.getId());
         }
+        else{
+            redisService.setDuplicateAccess(ipAddress, "Program_" + program.getId());
+        }
+
+
         return ProgramRes.of(program);
     }
 


### PR DESCRIPTION
# Issue
- #339 

# Issue 내용
- refreshToken의 유효성 검증을 작성했습니다.
- 이전 PR 내용 무시하시고 이걸로 이해하시면됩니다.
   -> 현재 DB에 있는 토큰과 요청으로 들어오는 토큰이 다르면 토큰 탈취로 간주합니다.
- redis에서 사용자에 대한 key값을 날립니다. -> 로그아웃 처리(다음 이슈에서 처리하겠습니다.)
- 에러 코드를 어떻게 해야 할 지 감이 안와서 일단 SNATCH_TOKEN으로 해두었습니다. 