### PR TITLE
[#341] 로그아웃 기능 구현 및 필터 예외 처리

### DIFF
--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_EMAIL("입력된 값의 이메일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 401
+    LOGOUTED_TOKEN("이미 로그아웃 처리된 토큰입니다.", HttpStatus.UNAUTHORIZED),
     SNATCH_TOKEN("Refresh Token 탈취를 감지하여 로그아웃 처리됩니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/festival/common/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/festival/common/redis/EmbeddedRedisConfig.java
@@ -9,8 +9,8 @@ import redis.embedded.RedisServer;
 
 import java.net.ServerSocket;
 
-//@Configuration
-//@Profile("dev")
+@Configuration
+@Profile("dev")
 public class EmbeddedRedisConfig {
 
     private RedisServer redisServer;

--- a/src/main/java/com/festival/common/redis/RedisService.java
+++ b/src/main/java/com/festival/common/redis/RedisService.java
@@ -30,7 +30,12 @@ public class RedisService {
     }
 
     public void setRefreshToken(String username, String refreshToken){
-        setData(username, refreshToken, refreshExpirationTime, TimeUnit.SECONDS);
+        setData("Login_" + username, refreshToken, refreshExpirationTime, TimeUnit.SECONDS);
+    }
+    public boolean isLogin(String username){
+        if(getData("Login_" + username) != null)
+            return true;
+        return false;
     }
 
     public boolean isDuplicateAccess(String ipAddress, String domainName) {
@@ -53,7 +58,7 @@ public class RedisService {
         redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);
     }
 
-    public Object getData(String key) {
+    private Object getData(String key) {
         return redisTemplate.opsForValue().get(key);
     }
 
@@ -62,6 +67,14 @@ public class RedisService {
     }
 
     public void deleteRefreshToken(String name) {
-        deleteData(name);
+        deleteData("Login_" + name);
+    }
+
+    public String getRefreshToken(String name) {
+        return getData("Login_" + name).toString();
+    }
+
+    public Long getViewCount(String key) {
+        return Long.parseLong((String) getData(key));
     }
 }

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -34,15 +34,15 @@ public class SchedulerRunner {
             String[] splitKey = key.split("_");
             switch (splitKey[0]) {
                 case "Booth" -> {
-                    boothService.increaseBoothViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
+                    boothService.increaseBoothViewCount( redisService.getViewCount(key), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Guide" -> {
-                    guideService.increaseGuideViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
+                    guideService.increaseGuideViewCount(redisService.getViewCount(key), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
                 case "Program" -> {
-                    programService.increaseProgramViewCount(Long.parseLong((String) redisService.getData(key)), Long.parseLong(splitKey[2]));
+                    programService.increaseProgramViewCount(redisService.getViewCount(key), Long.parseLong(splitKey[2]));
                     redisService.deleteData(key);
                 }
             }

--- a/src/main/java/com/festival/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/festival/common/security/JwtTokenProvider.java
@@ -101,7 +101,14 @@ public class JwtTokenProvider {
     }
 
     public Claims parseClaims(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        }
+        catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
     }
 
 
@@ -135,5 +142,10 @@ public class JwtTokenProvider {
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token);
+    }
+
+    public void checkLogin(String accessToken) {
+        if (redisService.isLogin(parseClaims(accessToken).getSubject()) == false)
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
     }
 }

--- a/src/main/java/com/festival/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/festival/common/security/JwtTokenProvider.java
@@ -146,6 +146,6 @@ public class JwtTokenProvider {
 
     public void checkLogin(String accessToken) {
         if (redisService.isLogin(parseClaims(accessToken).getSubject()) == false)
-            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
+            throw new InvalidException(ErrorCode.LOGOUTED_TOKEN);
     }
 }

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,6 +41,14 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<JwtTokenRes> loginMember(@Valid MemberLoginReq loginReq) {
         return ResponseEntity.ok().body(memberService.login(loginReq));
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<String> logoutMember() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ResponseEntity.ok().body(memberService.logout(username));
     }
 
     @GetMapping("/rotate")

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -73,15 +73,22 @@ public class MemberService {
      *  3. 다르다면 토큰 탈취로 간주 후 로그아웃 처리 + 예외 처리
      */
     public JwtTokenRes rotateToken(String requestRefreshToken) {
-        jwtTokenProvider.validateAccessToken(requestRefreshToken);
+        jwtTokenProvider.validateRefreshToken(requestRefreshToken);
         Authentication authentication = jwtTokenProvider.getAuthentication(requestRefreshToken);
-        String currentRefreshToken = (String) redisService.getData(authentication.getName());
+
+        String currentRefreshToken = redisService.getRefreshToken(authentication.getName());
+
         if(!currentRefreshToken.equals(requestRefreshToken)) {
-            redisService.deleteRefreshToken(authentication.getName());
+            logout(authentication.getName());
             throw new ForbiddenException(SNATCH_TOKEN);
         }
 
         redisService.rotateRefreshToken(authentication.getName(), requestRefreshToken);
         return jwtTokenProvider.createJwtToken(authentication);
+    }
+
+    public String logout(String username){
+        redisService.deleteRefreshToken(username);
+        return "로그아웃 처리 되었습니다.";
     }
 }

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
 
     @Transactional
     public Long join(MemberJoinReq memberJoinReq) {
-        if (isLoginIdSave(memberJoinReq.getUsername())) {
+        if (isExistsId(memberJoinReq.getUsername())) {
             throw new DuplicationException(DUPLICATION_ID);
         }
         Member member = Member.of(memberJoinReq, passwordEncoder.encode(memberJoinReq.getPassword()));
@@ -55,7 +55,7 @@ public class MemberService {
         return memberRepository.findByUsername(username).orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
     }
 
-    private boolean isLoginIdSave(String email) {
+    private boolean isExistsId(String email) {
         return memberRepository.existsByUsername(email);
     }
     private Authentication attemptAuthenticate(MemberLoginReq loginReq) {


### PR DESCRIPTION
# Issue
- #341 

# Issue 내용
- 저장소(Redis)에 PK를 key값으로 RefreshToken이 등록 돼 있으면 로그인한 것으로 간주합니다.
- 이에 따라 유효한 accessToken을 가지고 접근했을 때에도 로그아웃 처리 돼 있다면 만료된 토큰으로 예외 처리합니다.
- 기존의 GlobalExceptionHandler는 컨트롤러 단의 예외를 처리하는 것으로 Filter예외 처리를 따로 작성했습니다.
- 이미 존재하는 아이디에 대한 처리를 하는 메서드명을 수정했습니다. isExistId