### PR TITLE
[#401] 조회수 로직 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MARIA DB
 
 
 <a href= "https://bedecked-hosta-ff2.notion.site/feat-Redis-4c30c3012b984ba181b0c5810e49f575?pvs=4" target="_blank">  1. 게시물 별 조회수 증감 로직(feat.Redis)</a><br/>
-<a href= "https://bedecked-hosta-ff2.notion.site/JWT-d0c64afe1bdf4a9dbee814c5df778e57?pvs=4" target="_blank">  2. JWT 인증 흐름</a><br/>
-<a href= "https://bedecked-hosta-ff2.notion.site/dee8e72c02e044f882f19392b1cd413f?pvs=4" target="_blank">  3. 로그인/로그아웃 인증 흐름</a><br/>
-<a href= "https://bedecked-hosta-ff2.notion.site/d4e79a01056747cf811cbec94324fb32?pvs=4" target="_blank">  4. 운영 상태 관리 로직</a><br/>
-<a href= "https://bedecked-hosta-ff2.notion.site/Redis-RDB-a5a749ab80a4457c87d42f316e3a9e71?pvs=4" target="_blank">  5. Redis RDB 성능테스트 기록</a><br/>
+<a href= "https://bedecked-hosta-ff2.notion.site/JWT-d0c64afe1bdf4a9dbee814c5df778e57?pvs=4" target="_blank">  2. JWT 인증 흐름(feat.Redis)</a><br/>
+<a href= "https://bedecked-hosta-ff2.notion.site/dee8e72c02e044f882f19392b1cd413f?pvs=4" target="_blank">  3. 로그인/로그아웃 인증 흐름(feat.Redis)</a><br/>
+<a href= "https://bedecked-hosta-ff2.notion.site/d4e79a01056747cf811cbec94324fb32?pvs=4" target="_blank">  4. 운영 상태 관리 로직(feat.Redis)</a><br/>
+<a href= "https://bedecked-hosta-ff2.notion.site/Redis-RDB-a5a749ab80a4457c87d42f316e3a9e71?pvs=4" target="_blank">  5. Redis RDB 성능테스트 기록(feat.Redis)</a><br/>

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -28,27 +28,27 @@ public class SchedulerRunner {
      * @Description
      * 설정한 업데이트 주기에 따라 Redis에 쌓여있던 조회수를 RDB에 한번에 반영합니다.
      */
-    @Scheduled(fixedDelay = 3600000)
+    @Scheduled(fixedDelay = 360000)
     public void updateViewCount()
     {
-        Set<String> keySet = redisService.getKeySet("*Id*");
+        Set<String> keySet = redisService.getKeySet("viewCount*");
         for(String key : keySet){
-            String[] splitKey = key.split("_");
-            switch (splitKey[0]) {
+            String[] splitKey = key.split("_"); // 0 : viewCount, 1 : Domain명, 2 : Entity_Id
+            switch (splitKey[1]) {
                 case "Booth" -> {
-                    boothService.increaseBoothViewCount( redisService.getViewCount(key), Long.parseLong(splitKey[2]));
+                    boothService.increaseBoothViewCount( Long.parseLong(splitKey[2]), redisService.getViewCount(key));
                     redisService.deleteData(key);
                 }
                 case "Guide" -> {
-                    guideService.increaseGuideViewCount(redisService.getViewCount(key), Long.parseLong(splitKey[2]));
+                    guideService.increaseGuideViewCount(Long.parseLong(splitKey[2]), redisService.getViewCount(key));
                     redisService.deleteData(key);
                 }
                 case "Program" -> {
-                    programService.increaseProgramViewCount(redisService.getViewCount(key), Long.parseLong(splitKey[2]));
+                    programService.increaseProgramViewCount(Long.parseLong(splitKey[2]), redisService.getViewCount(key));
                     redisService.deleteData(key);
                 }
                 case "ViewCount" ->{
-                    viewCountService.update(redisService.getViewCount(key), Long.parseLong(splitKey[2]));
+                    viewCountService.update(Long.parseLong(splitKey[2]), redisService.getViewCount(key));
                     redisService.deleteData(key);
                 }
             }

--- a/src/main/java/com/festival/domain/booth/service/BoothService.java
+++ b/src/main/java/com/festival/domain/booth/service/BoothService.java
@@ -68,7 +68,7 @@ public class BoothService {
     public BoothRes getBooth(Long id, String ipAddress) {
         Booth booth = checkingDeletedStatus(boothRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Booth_" + booth.getId())) {
-            redisService.increaseRedisViewCount("Booth_Id_" + booth.getId());
+            redisService.increaseRedisViewCount("viewCount_" + "Booth_" + booth.getId());
             redisService.setDuplicateAccess(ipAddress, "Booth_" + booth.getId());
         }
 

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -64,7 +64,7 @@ public class GuideService {
     public GuideRes getGuide(Long id, String ipAddress){
         Guide guide = checkingDeletedStatus(guideRepository.findById(id));
         if(!redisService.isDuplicateAccess(ipAddress, "Guide_" + guide.getId())) {
-            redisService.increaseRedisViewCount("Guide_Id_" + guide.getId());
+            redisService.increaseRedisViewCount("viewCount_" + "Guide_" + guide.getId());
             redisService.setDuplicateAccess(ipAddress, "Guide_" + guide.getId());
         }
 

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-/*
 
     @PreAuthorize("isAnonymous()")
     @Operation(summary = "회원가입")
@@ -40,7 +39,7 @@ public class MemberController {
         memberService.join(memberJoinReq);
         return ResponseEntity.ok().build();
     }
-*/
+
 
     @PreAuthorize("isAnonymous()")
     @Operation(summary = "로그인")
@@ -60,7 +59,6 @@ public class MemberController {
 
     @GetMapping("/rotate")
     public JwtTokenRes rotateToken(HttpServletRequest request){
-        log.info("rotateContoller");
         String refreshToken = JwtTokenUtils.extractBearerToken(request.getHeader("refreshToken"));
 
         if(refreshToken.isBlank())

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -93,7 +93,7 @@ public class ProgramService {
     public ProgramRes getProgram(Long programId, String ipAddress) {
         Program program = checkingDeletedStatus(programRepository.findById(programId));
         if(!redisService.isDuplicateAccess(ipAddress, "Program_" + program.getId())) {
-            redisService.increaseRedisViewCount("Program_Id_" + program.getId());
+            redisService.increaseRedisViewCount("viewCount_" + "Program_" + program.getId());
             redisService.setDuplicateAccess(ipAddress, "Program_" + program.getId());
         }
 


### PR DESCRIPTION
# Issue 
- #401 

# Issue 내용
`boothService.increaseBoothViewCount( redisService.getViewCount(key), Long.parseLong(splitKey[2]));`

```    
public void increaseBoothViewCount(Long id, Long viewCount) {
        Booth booth = boothRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOTH));
        booth.increaseViewCount(viewCount);
}
```
- 조회 수에 해당하는 행(보통 1)에 id만큼 조회수를 더해주고 있었습니다.
텀이 짧게 설정되어있었고 사용자가 들어오자마자 업데이트를 쳐버리기 때문에
보통 1번 엔티티에 조회수를 올려주고 있었던 것
- Redis에 조회수를 저장하는 기존 Domain_Id_1 형식에서 viewCount_Domain_1 의 형태로 수정했습니다.

##
