### PR TITLE
[#403] 대나무숲 작성 시간 반환값 추가

### DIFF
--- a/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
@@ -3,22 +3,28 @@ package com.festival.domain.bambooforest.dto;
 import com.festival.domain.bambooforest.model.BamBooForest;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class BamBooForestRes {
 
     private Long id;
     private String content;
+    private LocalDateTime createdAt;
 
     @Builder
-    public BamBooForestRes(Long id, String content) {
+    public BamBooForestRes(Long id, String content, LocalDateTime createdAt) {
         this.id = id;
         this.content = content;
+        this.createdAt = createdAt;
     }
 
     public static BamBooForestRes of(BamBooForest bamBooForest){
         return BamBooForestRes.builder()
                 .id(bamBooForest.getId())
-                .content(bamBooForest.getContent()).build();
+                .content(bamBooForest.getContent())
+                .createdAt(bamBooForest.getCreatedDate())
+                .build();
     }
 }

--- a/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
+++ b/src/main/java/com/festival/domain/bambooforest/dto/BamBooForestRes.java
@@ -11,20 +11,20 @@ public class BamBooForestRes {
 
     private Long id;
     private String content;
-    private LocalDateTime createdAt;
+    private LocalDateTime createdDate;
 
     @Builder
-    public BamBooForestRes(Long id, String content, LocalDateTime createdAt) {
+    public BamBooForestRes(Long id, String content, LocalDateTime createdDate) {
         this.id = id;
         this.content = content;
-        this.createdAt = createdAt;
+        this.createdDate = createdDate;
     }
 
     public static BamBooForestRes of(BamBooForest bamBooForest){
         return BamBooForestRes.builder()
                 .id(bamBooForest.getId())
                 .content(bamBooForest.getContent())
-                .createdAt(bamBooForest.getCreatedDate())
+                .createdDate(bamBooForest.getCreatedDate())
                 .build();
     }
 }


### PR DESCRIPTION
# Issue
- #403 

# Issue 내용
- 대나무 숲 응답 데이터 구조에 엔티티 생성 시간 `createdDate` 을 추가하였습니다.


## 수정 전
        {
            "id": 5,
            "content": "contant"
        }

## 수정 후
        {
            "id": 5,
            "content": "contant",
            "createdDate": "2023-10-24T22:11:49.982971"
        }
