### PR TITLE
[#405] 검색결과 게시물 상태 필터링

### DIFF
--- a/src/main/java/com/festival/domain/booth/model/Booth.java
+++ b/src/main/java/com/festival/domain/booth/model/Booth.java
@@ -41,6 +41,7 @@ public class Booth extends BaseEntity {
     private float longitude;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private OperateStatus operateStatus;
 
     @Column(nullable = false)

--- a/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.festival.domain.booth.repository.impl;
 
+import com.festival.common.base.OperateStatus;
 import com.festival.domain.booth.controller.dto.BoothPageRes;
 import com.festival.domain.booth.controller.dto.BoothSearchRes;
 import com.festival.domain.booth.controller.dto.QBoothSearchRes;
@@ -78,7 +79,8 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
                .from(booth)
                .where(
                        eqKeyword(keyword),
-                      booth.deleted.eq(false)
+                       booth.deleted.eq(false),
+                       booth.operateStatus.eq(OperateStatus.OPERATE)
                )
                .orderBy(booth.viewCount.desc(), operateStatusAsc)
                .fetch();

--- a/src/main/java/com/festival/domain/program/model/Program.java
+++ b/src/main/java/com/festival/domain/program/model/Program.java
@@ -52,6 +52,7 @@ public class Program extends BaseEntity {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private OperateStatus operateStatus;
 

--- a/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
+++ b/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.festival.domain.program.repository.impl;
 
+import com.festival.common.base.OperateStatus;
 import com.festival.domain.program.dto.ProgramPageRes;
 import com.festival.domain.program.dto.ProgramSearchRes;
 import com.festival.domain.program.dto.QProgramSearchRes;
@@ -76,7 +77,8 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
                 .from(program)
                 .where(
                         keywordEqTitleOrSubTitle(keyword),
-                        program.deleted.eq(false)
+                        program.deleted.eq(false),
+                        program.operateStatus.eq(OperateStatus.OPERATE)
                 )
                 .orderBy(operateStatusASC, program.viewCount.desc())
                 .fetch();


### PR DESCRIPTION
# Issue
- #405 

## INFO
`SchedulerRunner` 의 `updateOperateStatus` 가 정상 동작하는지 확인 필요
    
→ EndDate 값을 기준으로 Status Update

자세한 내용은 Notion Millicon > 고도화 리스트업 > 검색결과 게시물 상태 필터링 페이지 확인