### PR TITLE
[#411] 테스트 케이스 추가 및 리팩토링 작업 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 jar {
@@ -112,50 +113,26 @@ tasks.register('updateVersion') {
     }
 }
 
-//
-//def frontendDir = "$projectDir/src/main/withfestival-front"
-//
-//sourceSets {
-//    main {
-//        resources { srcDirs = ["$projectDir/src/main/resources"]
-//        }
-//    }
-//}
-//
-//processResources { dependsOn "copyReactBuildFiles" }
-//
-//task installReact(type: Exec) {
-//    workingDir "$frontendDir"
-//    inputs.dir "$frontendDir"
-//    group = BasePlugin.BUILD_GROUP
-//    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
-//        commandLine "npm.cmd", "install", "-g", "nvm"
-//        commandLine "nvm", "install", "16.15.0"
-//        commandLine "nvm", "use", "16.15.0"
-//        commandLine "npm.cmd", "audit", "fix"
-//        commandLine 'npm.cmd', 'install'
-//    } else {
-//        commandLine "wget", "-qO-", "https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh", "|", "bash"
-//        commandLine "/bin/bash", "-c", "source ~/.nvm/nvm.sh && nvm install 16.15.0 && nvm use 16.15.0"
-//        commandLine "npm", "audit", "fix"
-//        commandLine 'npm', 'install'
-//    }
-//}
-//
-//task buildReact(type: Exec) {
-//    dependsOn "installReact"
-//    workingDir "$frontendDir"
-//    inputs.dir "$frontendDir"
-//    group = BasePlugin.BUILD_GROUP
-//    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
-//        commandLine "npm.cmd", "run-script", "build"
-//    } else {
-//        commandLine 'bash', '-c', 'source ~/.nvm/nvm.sh && nvm use 16.15.0 && npm run-script build'
-//    }
-//}
-//
-//task copyReactBuildFiles(type: Copy) {
-//    dependsOn "buildReact"
-//    from "$frontendDir/build"
-//    into "$projectDir/src/main/resources/static"
-//}
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "com/festival/**/dto/*",
+                    "com/festival/**/vo/*",
+                    "com/festival/**/data/*",
+                    "com/festival/**/exception/*",
+                    "com/festival/**/scheduler/*",
+                    "com/festival/**/*Config.class",
+                    "com/festival/**/*Jdbc*.class",
+                    "com/festival/**/Q*.class",
+                    "com/festival/**/FestivalApplication.class",
+            ])
+        }))
+    }
+}

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/festival/common/exception/ErrorCode.java
+++ b/src/main/java/com/festival/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     INVALID_STATUS("입력된 값의 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_DATE("입력된 값의 날짜 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_EMAIL("입력된 값의 이메일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PARAMETER("필수 파라미터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 401
     LOGOUTED_TOKEN("이미 로그아웃 처리된 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/festival/common/scheduler/SchedulerRunner.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 @RequiredArgsConstructor
@@ -61,7 +62,8 @@ public class SchedulerRunner {
      */
     @Scheduled(cron = "0 0 0 * * *")
     public void updateOperateStatus() {
-        programService.settingProgramStatus();
-        boothService.settingBoothStatus();
+        LocalDate registeredDate = LocalDate.now();
+        programService.settingProgramStatus(registeredDate);
+        boothService.settingBoothStatus(registeredDate);
     }
 }

--- a/src/main/java/com/festival/domain/booth/model/Booth.java
+++ b/src/main/java/com/festival/domain/booth/model/Booth.java
@@ -67,7 +67,8 @@ public class Booth extends BaseEntity {
     private LocalDate endDate;
 
     @Builder
-    private Booth(String title, String subTitle, String content, float latitude, float longitude, boolean deleted, OperateStatus operateStatus, BoothType type, LocalDate startDate, LocalDate endDate) {
+    private Booth(String title, String subTitle, String content, float latitude, float longitude, boolean deleted,
+                  OperateStatus operateStatus, BoothType type, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.subTitle = subTitle;
         this.content = content;
@@ -87,7 +88,9 @@ public class Booth extends BaseEntity {
                 .content(boothReq.getContent())
                 .latitude(boothReq.getLatitude())
                 .longitude(boothReq.getLongitude())
-                .operateStatus(resolveOperateStatus(LocalDate.now(), boothReq.getOperateStatus(), boothReq.getStartDate(), boothReq.getEndDate()))
+                .operateStatus(resolveOperateStatus(
+                        LocalDate.now(), boothReq.getOperateStatus(), boothReq.getStartDate(), boothReq.getEndDate())
+                )
                 .startDate(boothReq.getStartDate())
                 .endDate(boothReq.getEndDate())
                 .deleted(false)
@@ -97,14 +100,14 @@ public class Booth extends BaseEntity {
         this.image = image;
     }
 
-    private static OperateStatus resolveOperateStatus(LocalDate currentDate,String operateStatus, LocalDate startDate, LocalDate endDate){
+    private static OperateStatus resolveOperateStatus(LocalDate currentDate,String operateStatus,
+                                                      LocalDate startDate, LocalDate endDate){
         if(currentDate.isBefore(startDate))
             return OperateStatus.UPCOMING;
         else if (currentDate.isAfter(endDate)) {
             return OperateStatus.TERMINATE;
         }
         return OperateStatus.checkStatus(operateStatus);
-
     }
 
     public void connectMember(Member member){

--- a/src/main/java/com/festival/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/com/festival/domain/booth/repository/BoothRepository.java
@@ -1,5 +1,6 @@
 package com.festival.domain.booth.repository;
 
+import com.festival.common.base.OperateStatus;
 import com.festival.domain.booth.model.Booth;
 import com.festival.domain.guide.repository.GuideRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,8 +9,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BoothRepository extends JpaRepository<Booth, Long>, BoothRepositoryCustom {
-    Booth getBoothByTitle(String title);
-
-    List<Booth> findByStartDateEqualsAndOperateStatusEquals(LocalDate now, String value);
-    List<Booth> findByEndDateEquals(LocalDate now);
+    List<Booth> findByStartDateEqualsAndOperateStatusEquals(LocalDate inputDate, OperateStatus operateStatus);
+    List<Booth> findByEndDateEquals(LocalDate inputDate);
 }

--- a/src/main/java/com/festival/domain/booth/repository/BoothRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/booth/repository/BoothRepositoryCustom.java
@@ -1,16 +1,11 @@
 package com.festival.domain.booth.repository;
 
 import com.festival.domain.booth.controller.dto.BoothPageRes;
-import com.festival.domain.booth.controller.dto.BoothRes;
-import com.festival.domain.booth.model.Booth;
 import com.festival.domain.booth.service.vo.BoothListSearchCond;
-import org.springframework.data.domain.Pageable;
 import com.festival.domain.booth.controller.dto.BoothSearchRes;
 import java.util.List;
 
 public interface BoothRepositoryCustom {
-    BoothPageRes getList(BoothListSearchCond boothListSearchCond);
+    BoothPageRes getBoothList(BoothListSearchCond boothListSearchCond);
     List<BoothSearchRes> searchBoothList(String keyword);
-
-
 }

--- a/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
@@ -9,10 +9,8 @@ import com.festival.domain.booth.model.BoothType;
 import com.festival.domain.booth.repository.BoothRepositoryCustom;
 import com.festival.domain.booth.service.vo.BoothListSearchCond;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -37,8 +35,7 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    public BoothPageRes getList(BoothListSearchCond boothListSearchCond) {
-
+    public BoothPageRes getBoothList(BoothListSearchCond boothListSearchCond) {
         List<Booth> result = queryFactory
                 .selectFrom(booth)
                 .join(booth.image).fetchJoin()
@@ -93,5 +90,4 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
     private static BooleanExpression eqType(String type) {
         return type == null ? null : booth.type.eq(BoothType.valueOf(type));
     }
-
 }

--- a/src/main/java/com/festival/domain/guide/model/Guide.java
+++ b/src/main/java/com/festival/domain/guide/model/Guide.java
@@ -50,10 +50,6 @@ public class Guide extends BaseEntity {
         this.viewCount += viewCount;
     }
 
-    public void decreaseViewCount(Long viewCount) {
-        this.viewCount -= viewCount;
-    }
-
     public void connectMember(Member member) {
         this.member = member;
     }
@@ -62,7 +58,4 @@ public class Guide extends BaseEntity {
         this.deleted = true;
     }
 
-    private static OperateStatus settingStatus(String guideStatus) {
-        return OperateStatus.checkStatus(guideStatus);
-    }
 }

--- a/src/main/java/com/festival/domain/guide/service/GuideService.java
+++ b/src/main/java/com/festival/domain/guide/service/GuideService.java
@@ -72,7 +72,6 @@ public class GuideService {
     }
 
     public GuidePageRes getGuideList(GuideListReq guideListReq) {
-
         return guideRepository.getList(PageRequest.of(guideListReq.getPage(), guideListReq.getSize()));
     }
 
@@ -80,12 +79,6 @@ public class GuideService {
     public void increaseGuideViewCount(Long id, Long viewCount) {
         Guide guide = guideRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_GUIDE));
         guide.increaseViewCount(viewCount);
-    }
-
-    @Transactional
-    public void decreaseGuideViewCount(Long id, Long viewCount) {
-        Guide guide = guideRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_GUIDE));
-        guide.decreaseViewCount(viewCount);
     }
 
     private Guide checkingDeletedStatus(Optional<Guide> guide) {

--- a/src/main/java/com/festival/domain/image/service/ImageService.java
+++ b/src/main/java/com/festival/domain/image/service/ImageService.java
@@ -37,7 +37,9 @@ public class ImageService {
     /**
      * @Description
      * 이미지 경로만 DB에 저장하는 방식으로 구현해두었습니다.
+     * 미사용 메소드임으로 주석 처리 합니다.
      */
+    /*
     public Image createImage(MultipartFile mainFile, List<MultipartFile> subFiles, String kind){
         String mainFilePath = null;
         List<String> subFilePaths = null;
@@ -55,15 +57,18 @@ public class ImageService {
                 .build();
     }
 
+
     private List<String> createSubImages(List<MultipartFile> subFiles, String kind) {
         return subFiles.stream().
                 map(f -> createImage(f, kind))
                 .collect(Collectors.toList());
     }
 
+
     private String createImage(MultipartFile mainFile, String kind) {
         return imageUtils.createFileName(mainFile.getOriginalFilename(), kind);
     }
+    */
 
     public void deleteImage(Image image) {
         imageUtils.deleteFiles(image);

--- a/src/main/java/com/festival/domain/member/controller/MemberController.java
+++ b/src/main/java/com/festival/domain/member/controller/MemberController.java
@@ -2,8 +2,6 @@ package com.festival.domain.member.controller;
 
 import com.festival.common.exception.ErrorCode;
 import com.festival.common.exception.custom_exception.BadRequestException;
-import com.festival.common.redis.RedisService;
-import com.festival.common.security.JwtTokenProvider;
 import com.festival.common.security.dto.JwtTokenRes;
 import com.festival.common.security.dto.MemberLoginReq;
 import com.festival.common.util.JwtTokenUtils;
@@ -17,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,14 +57,11 @@ public class MemberController {
     @GetMapping("/rotate")
     public JwtTokenRes rotateToken(HttpServletRequest request){
         String refreshToken = JwtTokenUtils.extractBearerToken(request.getHeader("refreshToken"));
-
-        if(refreshToken.isBlank())
+        if(refreshToken.isBlank()) {
             throw new BadRequestException(ErrorCode.EMPTY_REFRESH_TOKEN);
-
+        }
         memberService.checkLogin(refreshToken);
 
         return memberService.rotateToken(refreshToken);
     }
-
-
 }

--- a/src/main/java/com/festival/domain/member/service/MemberService.java
+++ b/src/main/java/com/festival/domain/member/service/MemberService.java
@@ -3,14 +3,12 @@ package com.festival.domain.member.service;
 import com.festival.common.exception.custom_exception.DuplicationException;
 import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
-import com.festival.common.redis.RedisService;
 import com.festival.common.security.JwtTokenProvider;
 import com.festival.common.security.dto.JwtTokenRes;
 import com.festival.common.security.dto.MemberLoginReq;
 import com.festival.common.util.JwtTokenUtils;
 import com.festival.domain.member.dto.MemberJoinReq;
 import com.festival.domain.member.model.Member;
-import com.festival.domain.member.model.MemberRole;
 import com.festival.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,7 +19,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.festival.common.exception.ErrorCode.*;
@@ -59,17 +56,6 @@ public class MemberService {
         return memberRepository.findByUsername(username).orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
     }
 
-    private boolean isExistsId(String email) {
-        return memberRepository.existsByUsername(email);
-    }
-    private Authentication attemptAuthenticate(MemberLoginReq loginReq) {
-        return authenticationManagerBuilder.getObject().authenticate(createAuthenticationToken(loginReq));
-    }
-
-    private static UsernamePasswordAuthenticationToken createAuthenticationToken(MemberLoginReq loginReq) {
-        return new UsernamePasswordAuthenticationToken(loginReq.getUsername(), loginReq.getPassword());
-    }
-
     /**
      * @Description
      *  1. 요청으로 들어온 RT를 검증
@@ -101,5 +87,16 @@ public class MemberService {
 
     public void checkLogin(String refreshToken) {
         jwtTokenProvider.checkLoginByRefreshToken(refreshToken);
+    }
+
+    private boolean isExistsId(String email) {
+        return memberRepository.existsByUsername(email);
+    }
+    private Authentication attemptAuthenticate(MemberLoginReq loginReq) {
+        return authenticationManagerBuilder.getObject().authenticate(createAuthenticationToken(loginReq));
+    }
+
+    private static UsernamePasswordAuthenticationToken createAuthenticationToken(MemberLoginReq loginReq) {
+        return new UsernamePasswordAuthenticationToken(loginReq.getUsername(), loginReq.getPassword());
     }
 }

--- a/src/main/java/com/festival/domain/program/dto/ProgramSearchRes.java
+++ b/src/main/java/com/festival/domain/program/dto/ProgramSearchRes.java
@@ -11,16 +11,15 @@ public class ProgramSearchRes {
     private Long id;
     private String title;
     private String subTitle;
-    private String status;
+    private String operateStatus;
     private String mainFilePath;
 
     @QueryProjection
-    public ProgramSearchRes(Long id, String title, String subTitle, String status, String mainFilePath) {
+    public ProgramSearchRes(Long id, String title, String subTitle, String operateStatus, String mainFilePath) {
         this.id = id;
         this.title = title;
         this.subTitle = subTitle;
-        this.status = status;
+        this.operateStatus = operateStatus;
         this.mainFilePath = mainFilePath;
     }
-
 }

--- a/src/main/java/com/festival/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/festival/domain/program/repository/ProgramRepository.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface ProgramRepository extends JpaRepository<Program, Long> , ProgramRepositoryCustom{
-
-    List<Program> findByStartDateEqualsAndOperateStatusEquals(LocalDate currentDate, String operateStatus);
+    List<Program> findByStartDateEqualsAndOperateStatusEquals(LocalDate startDate, OperateStatus operateStatus);
     List<Program> findByEndDateEquals(LocalDate currentDate);
 }

--- a/src/main/java/com/festival/domain/program/repository/ProgramRepositoryCustom.java
+++ b/src/main/java/com/festival/domain/program/repository/ProgramRepositoryCustom.java
@@ -7,6 +7,6 @@ import com.festival.domain.program.service.vo.ProgramSearchCond;
 import java.util.List;
 
 public interface ProgramRepositoryCustom {
-    ProgramPageRes getList(ProgramSearchCond programSearchCond);
+    ProgramPageRes getProgramList(ProgramSearchCond programSearchCond);
     List<ProgramSearchRes> searchProgramList(String keyword);
 }

--- a/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
+++ b/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
@@ -22,7 +22,7 @@ import static com.festival.domain.program.model.QProgram.program;
 
 public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
 
-    private JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
     private final OrderSpecifier<Integer> operateStatusASC = new CaseBuilder()
             .when(program.operateStatus.stringValue().eq("OPERATE")).then(1)
@@ -34,12 +34,8 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 
-    private static BooleanExpression TypeEq(String type) {
-        return type == null ? null : program.type.stringValue().eq(type);
-    }
-
     @Override
-    public ProgramPageRes getList(ProgramSearchCond programSearchCond) {
+    public ProgramPageRes getProgramList(ProgramSearchCond programSearchCond) {
         List<Program> result = queryFactory
                 .selectFrom(program)
                 .join(program.image).fetchJoin()
@@ -82,6 +78,10 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
                 )
                 .orderBy(operateStatusASC, program.viewCount.desc())
                 .fetch();
+    }
+
+    private static BooleanExpression TypeEq(String type) {
+        return type == null ? null : program.type.stringValue().eq(type);
     }
 
     private static BooleanExpression keywordEqTitleOrSubTitle(String keyword) {

--- a/src/main/java/com/festival/domain/program/service/ProgramService.java
+++ b/src/main/java/com/festival/domain/program/service/ProgramService.java
@@ -71,9 +71,8 @@ public class ProgramService {
     }
 
     @Transactional
-    public void settingProgramStatus() {
-        LocalDate registeredDate = LocalDate.now();
-        programRepository.findByStartDateEqualsAndOperateStatusEquals(registeredDate, OperateStatus.UPCOMING.getValue())
+    public void settingProgramStatus(LocalDate registeredDate) {
+        programRepository.findByStartDateEqualsAndOperateStatusEquals(registeredDate, OperateStatus.UPCOMING)
                 .forEach(p -> p.changeStatus(OperateStatus.OPERATE.getValue()));
 
         programRepository.findByEndDateEquals(registeredDate)
@@ -102,7 +101,7 @@ public class ProgramService {
     }
 
     public ProgramPageRes getProgramList(ProgramListReq programListReq) {
-        return programRepository.getList(
+        return programRepository.getProgramList(
                 ProgramSearchCond.builder()
                 .type(programListReq.getType())
                 .pageable(PageRequest.of(programListReq.getPage(), programListReq.getSize()))

--- a/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/timetable/repository/impl/TimeTableRepositoryImpl.java
@@ -36,9 +36,6 @@ public class TimeTableRepositoryImpl implements TimeTableRepositoryCustom {
     }
 
     private static BooleanExpression isWithinPeriod(LocalDateTime startTime, LocalDateTime endTime) {
-        if (startTime == null || endTime == null) {
-            return null;
-        }
         return timeTable.startTime.goe(startTime)
                 .and(timeTable.endTime.loe(endTime));
     }

--- a/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
+++ b/src/main/java/com/festival/domain/timetable/service/TimeTableService.java
@@ -60,6 +60,10 @@ public class TimeTableService {
     }
 
     public List<TimeTableRes> getTimeTableList(TimeTableDateReq timeTableDateReq) {
+        if (timeTableDateReq.getStartTime() == null || timeTableDateReq.getEndTime() == null) {
+            throw new NotFoundException(ErrorCode.INVALID_PARAMETER);
+        }
+
         TimeTableSearchCond timeTableSearchCond =TimeTableSearchCond.builder()
                 .startTime(timeTableDateReq.getStartTime())
                 .endTime(timeTableDateReq.getEndTime())

--- a/src/test/java/com/festival/domain/bambooforest/controller/BambooForestIntegrationTest.java
+++ b/src/test/java/com/festival/domain/bambooforest/controller/BambooForestIntegrationTest.java
@@ -1,20 +1,15 @@
 package com.festival.domain.bambooforest.controller;
 
-import com.festival.common.base.OperateStatus;
 import com.festival.domain.bambooforest.dto.BamBooForestPageRes;
 import com.festival.domain.bambooforest.dto.BamBooForestReq;
 import com.festival.domain.bambooforest.model.BamBooForest;
 import com.festival.domain.bambooforest.repository.BamBooForestRepository;
 import com.festival.domain.member.model.Member;
-import com.festival.domain.program.dto.ProgramRes;
 import com.festival.domain.util.ControllerTestSupport;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -23,13 +18,12 @@ import java.util.List;
 import static com.festival.domain.member.model.MemberRole.ADMIN;
 import static com.festival.domain.member.model.MemberRole.MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.*;
-import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class BambooForestIntegrationTest extends ControllerTestSupport {
 
@@ -108,7 +102,45 @@ class BambooForestIntegrationTest extends ControllerTestSupport {
                 .andExpect(status().isNotFound());
     }
 
+    @DisplayName("대나무숲 게시물 리스트를 조회한다. 이때 페이징 처리가 되어 10개씩 표시된다. 테스트에서는 3개씩 처리하는 것으로 변경한다.")
+    @Test
+    void getBamBooForestList() throws Exception {
+        //given
+        BamBooForest bamBooForest1 = BamBooForest.builder()
+                .content("content1")
+                .build();
+        BamBooForest bamBooForest2 = BamBooForest.builder()
+                .content("content2")
+                .build();
+        BamBooForest bamBooForest3 = BamBooForest.builder()
+                .content("content3")
+                .build();
+        BamBooForest bamBooForest4 = BamBooForest.builder()
+                .content("content4")
+                .build();
+        BamBooForest bamBooForest5 = BamBooForest.builder()
+                .content("content5")
+                .build();
+        bamBooForestRepository.saveAllAndFlush(List.of(bamBooForest1, bamBooForest2, bamBooForest3, bamBooForest4, bamBooForest5));
 
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/v2/bambooforest/list")
+                                .contentType(APPLICATION_JSON_VALUE)
+                                .param("page", "0")
+                                .param("size", "3")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        BamBooForestPageRes bamBooForestPageRes = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), BamBooForestPageRes.class);
+        assertThat(bamBooForestPageRes.getForestResList()).hasSize(3)
+                .extracting("content")
+                .containsExactlyInAnyOrder(bamBooForest5.getContent(), bamBooForest4.getContent(), bamBooForest3.getContent());
+    }
 
     private static BamBooForestReq createBamBooForestReq(String bambooForestContent, String mail, String operate) {
         return BamBooForestReq.builder()

--- a/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
+++ b/src/test/java/com/festival/domain/bambooforest/service/BamBooForestServiceTest.java
@@ -4,25 +4,28 @@ import com.festival.common.exception.ErrorCode;
 import com.festival.common.exception.custom_exception.AlreadyDeleteException;
 import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
+import com.festival.domain.bambooforest.dto.BamBooForestPageRes;
 import com.festival.domain.bambooforest.dto.BamBooForestReq;
 import com.festival.domain.bambooforest.model.BamBooForest;
 import com.festival.domain.bambooforest.repository.BamBooForestRepository;
 import com.festival.domain.member.fixture.MemberFixture;
 import com.festival.domain.member.repository.MemberRepository;
 import com.festival.domain.member.service.MemberService;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static com.festival.common.exception.ErrorCode.NOT_FOUND_BAMBOO;
 import static com.festival.domain.bambooforest.fixture.BamBooForestFixture.TERMINATED_BAMBOOFOREST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -32,17 +35,19 @@ class BamBooForestServiceTest {
 
     @InjectMocks
     private BamBooForestService bamBooForestService;
+
     @Mock
     private BamBooForestRepository bamBooForestRepository;
+
     @Mock
     private MemberRepository memberRepository;
+
     @Mock
     private MemberService memberService;
 
     @DisplayName("대나무 숲을 생성한 후 boothId를 반환한다.")
     @Test
     void createBamBooForest() {
-
         //given
         BamBooForestReq bambooCreateReq = getBamBooForestCreateReq();
 
@@ -53,15 +58,12 @@ class BamBooForestServiceTest {
         Long bambooForestId = bamBooForestService.createBamBooForest(bambooCreateReq);
 
         //then
-        Assertions.assertThat(bambooForestId).isEqualTo(1L);
+        assertThat(bambooForestId).isEqualTo(1L);
     }
-
-
 
     @DisplayName("대나무 숲을 삭제하면 오류가 없을 시 정상흐름.")
     @Test
     void deleteBamBooForest1() {
-
         //given
         given(bamBooForestRepository.findById(1L))
                 .willReturn(Optional.of(getBamBooForest()));
@@ -70,19 +72,15 @@ class BamBooForestServiceTest {
         //when
         bamBooForestService.deleteBamBooForest(1L);
 
-
         //then
     }
-
 
     @DisplayName("존재하지 않는 대나무 숲을 삭제하면 NotFoundException를 반환한다.")
     @Test
     void deleteNotExistBamBooForest() {
-
         //given
         given(bamBooForestRepository.findById(1L))
                 .willThrow(new NotFoundException(NOT_FOUND_BAMBOO));
-
 
         //when & then
         assertThatThrownBy(() -> bamBooForestService.deleteBamBooForest(1L))
@@ -94,7 +92,6 @@ class BamBooForestServiceTest {
     @DisplayName("이미 삭제된 대나무 숲을 삭제하면 AlreadyDeletedException이 발생")
     @Test
     void deleteAlreadyDeletedBamBooForest() {
-
         //given
         given(bamBooForestRepository.findById(1L))
                 .willReturn(Optional.of(TERMINATED_BAMBOOFOREST));
@@ -109,7 +106,6 @@ class BamBooForestServiceTest {
     @DisplayName("권한 없는 사람이 대나무 숲을 삭제하면 ForbiddenException이 발생")
     @Test
     void deleteBamBooForest2() {
-
         //given
         given(bamBooForestRepository.findById(1L))
                 .willReturn(Optional.of(getBamBooForest()));
@@ -122,16 +118,22 @@ class BamBooForestServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN_DELETE);
     }
-/*
 
-    @DisplayName("조건에 맞는 대나무숲 리스트 반환한다.")
+    @DisplayName("조건에 맞는 대나무숲 게시물 리스트 반환한다.")
     @Test
     void getBamBooList(){
         //given
+        Pageable pageable = PageRequest.of(0, 10);
+        given(bamBooForestRepository.getList(pageable))
+                .willReturn(new BamBooForestPageRes());
+
         //when
+        BamBooForestPageRes bamBooForestPageRes = bamBooForestService.getBamBooForestList(pageable);
+
         //then
+        assertThat(bamBooForestPageRes).isNotNull();
     }
-*/
+
     private BamBooForest getBamBooForest(){
         BamBooForest bamBooForest = BamBooForest.builder()
                 .content("대나무 숲 글 내용")
@@ -140,11 +142,11 @@ class BamBooForestServiceTest {
         ReflectionTestUtils.setField(bamBooForest, "id", 1L);
         return bamBooForest;
     }
+
     private BamBooForestReq getBamBooForestCreateReq() {
         return BamBooForestReq.builder()
                 .content("대나무 숲 글 내용")
                 .contact("010-1234-5678")
                 .build();
     }
-
 }

--- a/src/test/java/com/festival/domain/booth/repository/BoothRepositoryTest.java
+++ b/src/test/java/com/festival/domain/booth/repository/BoothRepositoryTest.java
@@ -1,8 +1,23 @@
 package com.festival.domain.booth.repository;
 
+import com.festival.domain.booth.controller.dto.BoothPageRes;
+import com.festival.domain.booth.controller.dto.BoothSearchRes;
+import com.festival.domain.booth.model.Booth;
+import com.festival.domain.booth.service.vo.BoothListSearchCond;
+import com.festival.domain.image.model.Image;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.festival.common.base.OperateStatus.OPERATE;
+import static com.festival.domain.booth.model.BoothType.PUB;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @DataJpaTest
@@ -11,4 +26,116 @@ class BoothRepositoryTest {
     @Autowired
     private BoothRepository boothRepository;
 
+    @DisplayName("시작일과 같으면서 운영중인 부스를 조회한다.")
+    @Test
+    void findByStartDateEqualsAndOperateStatusEquals() throws Exception {
+        //given
+        LocalDate startedDate = LocalDate.of(2023, 11, 14);
+        LocalDate endedDate = LocalDate.of(2023, 11, 15);
+
+        Booth booth1 = createdBooth(startedDate, endedDate, "title1");
+        Booth booth2 = createdBooth(startedDate, endedDate, "title2");
+        Booth booth3 = createdBooth(startedDate, endedDate, "title3");
+        boothRepository.saveAllAndFlush(List.of(booth1, booth2, booth3));
+
+        //when
+        List<Booth> booths = boothRepository.findByStartDateEqualsAndOperateStatusEquals(startedDate, OPERATE);
+
+        //then
+        assertThat(booths).hasSize(3)
+                .extracting("title")
+                .containsExactlyInAnyOrder("title1", "title2", "title3");
+    }
+
+    @DisplayName("종료일이 같은 부스를 조회한다.")
+    @Test
+    void findByEndDateEquals() throws Exception {
+        //given
+        LocalDate startedDate = LocalDate.of(2023, 11, 14);
+        LocalDate endedDate = LocalDate.of(2023, 11, 15);
+
+        Booth booth1 = createdBooth(startedDate, endedDate, "title1");
+        Booth booth2 = createdBooth(startedDate, endedDate, "title2");
+        Booth booth3 = createdBooth(startedDate, endedDate, "title3");
+        boothRepository.saveAllAndFlush(List.of(booth1, booth2, booth3));
+
+        //when
+        List<Booth> booths = boothRepository.findByEndDateEquals(endedDate);
+
+        //then
+        assertThat(booths).hasSize(3)
+                .extracting("title")
+                .containsExactlyInAnyOrder("title1", "title2", "title3");
+    }
+
+    @DisplayName("부스 리스트를 조회한다.")
+    @Test
+    void getBoothList() throws Exception {
+        //given
+        LocalDate startedDate = LocalDate.of(2023, 11, 14);
+        LocalDate endedDate = LocalDate.of(2023, 11, 15);
+
+        Booth booth1 = createdBooth(startedDate, endedDate, "title1");
+        Booth booth2 = createdBooth(startedDate, endedDate, "title2");
+        Booth booth3 = createdBooth(startedDate, endedDate, "title3");
+        boothRepository.saveAllAndFlush(List.of(booth1, booth2, booth3));
+
+        //when
+        BoothListSearchCond boothListSearchCond = new BoothListSearchCond("OPERATE", "PUB", PageRequest.of(0, 6));
+        BoothPageRes boothPageRes = boothRepository.getBoothList(boothListSearchCond);
+
+        //then
+        assertThat(boothPageRes.getBoothResList()).hasSize(3)
+                .extracting("title")
+                .containsExactlyInAnyOrder("title1", "title2", "title3");
+        assertThat(boothPageRes.getPageNumber()).isEqualTo(0);
+        assertThat(boothPageRes.getTotalCount()).isEqualTo(3);
+        assertThat(boothPageRes.getTotalPage()).isEqualTo(1);
+        assertThat(boothPageRes.getPageSize()).isEqualTo(6);
+    }
+
+    @DisplayName("키워드가 포함된 부스 리스트를 조회한다.")
+    @Test
+    void searchBoothList() throws Exception {
+        //given
+        LocalDate startedDate = LocalDate.of(2023, 11, 14);
+        LocalDate endedDate = LocalDate.of(2023, 11, 15);
+
+        Booth booth1 = createdBooth(startedDate, endedDate, "title1");
+        Booth booth2 = createdBooth(startedDate, endedDate, "title2");
+        Booth booth3 = createdBooth(startedDate, endedDate, "title3");
+        boothRepository.saveAllAndFlush(List.of(booth1, booth2, booth3));
+
+        //when
+        String keyword = "title2";
+        List<BoothSearchRes> boothSearchRes = boothRepository.searchBoothList(keyword);
+
+        //then
+        assertThat(boothSearchRes).hasSize(1)
+                .extracting("title")
+                .containsExactlyInAnyOrder("title2");
+        assertThat(boothSearchRes.get(0)).isNotNull()
+                .extracting("title", "subTitle", "operateStatus", "mainFilePath")
+                .containsExactly("title2", "title2", "OPERATE", "mainFilePath");
+    }
+
+    private Booth createdBooth(LocalDate startedDate, LocalDate endedDate, String title) {
+        Booth booth = Booth.builder()
+                .title(title)
+                .subTitle(title)
+                .content("content")
+                .latitude(1.0f)
+                .longitude(1.0f)
+                .operateStatus(OPERATE)
+                .type(PUB)
+                .startDate(startedDate)
+                .endDate(endedDate)
+                .deleted(false)
+                .build();
+        booth.setImage(Image.builder()
+                .mainFilePath("mainFilePath")
+                .subFilePaths(List.of("subFilePaths"))
+                .build());
+        return booth;
+    }
 }

--- a/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
+++ b/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
@@ -5,11 +5,7 @@ import com.festival.common.exception.ErrorCode;
 import com.festival.common.exception.custom_exception.AlreadyDeleteException;
 import com.festival.common.exception.custom_exception.ForbiddenException;
 import com.festival.common.exception.custom_exception.NotFoundException;
-import com.festival.common.redis.RedisService;
-import com.festival.domain.booth.controller.dto.BoothListReq;
-import com.festival.domain.booth.controller.dto.BoothPageRes;
-import com.festival.domain.booth.controller.dto.BoothReq;
-import com.festival.domain.booth.controller.dto.BoothRes;
+import com.festival.domain.booth.controller.dto.*;
 import com.festival.domain.booth.fixture.BoothFixture;
 import com.festival.domain.booth.model.Booth;
 import com.festival.domain.booth.model.BoothType;
@@ -77,7 +73,6 @@ class BoothServiceTest {
         Assertions.assertThat(boothId).isEqualTo(1L);
     }
 
-
     @DisplayName("존재하지 않는 부스를 업데이트하면 NotFoundException을 반환한다.")
     @Test
     void updateNotExistBooth() throws IOException {
@@ -93,8 +88,8 @@ class BoothServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.NOT_FOUND_BOOTH);
-
     }
+
     @DisplayName("삭제된 부스를 업데이트하면 AlreadyDeletedException을 반환한다.")
     @Test
     void updateDeletedBooth() throws IOException {
@@ -109,10 +104,7 @@ class BoothServiceTest {
                 .isInstanceOf(AlreadyDeleteException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_DELETED);
-
     }
-
-
 
     @DisplayName("다른 사람이 부스를 업데이트하면 ForbiddenException을 반환한다.")
     @Test
@@ -133,6 +125,7 @@ class BoothServiceTest {
             .extracting("errorCode")
             .isEqualTo(ErrorCode.FORBIDDEN_UPDATE);
     }
+
     @DisplayName("Admin이 부스를 업데이트하면 boothId를 반환한다.")
     @Test
     void updateBooth3() throws IOException {
@@ -152,6 +145,7 @@ class BoothServiceTest {
         //then
         Assertions.assertThat(boothId).isEqualTo(booth.getId());
     }
+
     @DisplayName("부스의 관리자가 업데이트하면 boothId를 반환한다.")
     @Test
     void updateBooth4() throws IOException {
@@ -172,8 +166,6 @@ class BoothServiceTest {
         Assertions.assertThat(boothId).isEqualTo(booth.getId());
     }
 
-    //   ###############################################################
-
     @DisplayName("삭제된 부스의 상태값을 업데이트하면 AlreadyDeletedException을 반환한다.")
     @Test
     void updateBoothOperateStatus() throws IOException {
@@ -186,10 +178,7 @@ class BoothServiceTest {
                 .isInstanceOf(AlreadyDeleteException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_DELETED);
-
     }
-
-
 
     @DisplayName("다른 사람이 부스 상태값을 업데이트하면 ForbiddenException을 반환한다.")
     @Test
@@ -209,6 +198,7 @@ class BoothServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN_UPDATE);
     }
+
     @DisplayName("Admin이 부스 상태값을 업데이트하면 boothId를 반환한다.")
     @Test
     void updateBoothOperateStatus3() throws IOException {
@@ -227,6 +217,7 @@ class BoothServiceTest {
         //then
         Assertions.assertThat(boothId).isEqualTo(booth.getId());
     }
+
     @DisplayName("부스의 관리자가 업데이트하면 boothId를 반환한다.")
     @Test
     void updateBoothOperateStatus4() throws IOException {
@@ -253,14 +244,11 @@ class BoothServiceTest {
                 .willReturn(Optional.empty());
 
         //when & then
-        assertThatThrownBy(() ->boothService.updateBoothOperateStatus(OperateStatus.OPERATE.getValue(), 1L))
+        assertThatThrownBy(() -> boothService.updateBoothOperateStatus(OperateStatus.OPERATE.getValue(), 1L))
                 .isInstanceOf(NotFoundException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.NOT_FOUND_BOOTH);
-
     }
-
-    // #####################################################################
 
     @DisplayName("존재하지 않는 부스를 삭제하면 NotFoundException을 반환한다.")
     @Test
@@ -274,8 +262,8 @@ class BoothServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.NOT_FOUND_BOOTH);
-
     }
+
     @DisplayName("삭제된 부스를 삭제하면 AlreadyDeletedException을 반환한다.")
     @Test
     void deleteDeletedBooth() {
@@ -288,7 +276,6 @@ class BoothServiceTest {
                 .isInstanceOf(AlreadyDeleteException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_DELETED);
-
     }
 
     @DisplayName("다른 사람이 부스를 삭제하면 ForbiddenException을 반환한다.")
@@ -309,6 +296,7 @@ class BoothServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN_DELETE);
     }
+
     @DisplayName("Admin이 부스를 삭제하면 정상처리")
     @Test
     void deleteBooth3() {
@@ -324,6 +312,7 @@ class BoothServiceTest {
         //when && then
         boothService.deleteBooth(1L);
     }
+
     @DisplayName("부스의 관리자가 업데이트하면 정상동작")
     @Test
     void deleteBooth4(){
@@ -339,6 +328,7 @@ class BoothServiceTest {
         //when && then
         boothService.deleteBooth(1L);
     }
+
     @DisplayName("아이디에 맞는 부스를 반환한다.")
     @Test
     void getBoothTest(){
@@ -360,7 +350,7 @@ class BoothServiceTest {
     @Test
     void getBoothList(){
         //given
-        given(boothRepository.getList(any(BoothListSearchCond.class)))
+        given(boothRepository.getBoothList(any(BoothListSearchCond.class)))
                 .willReturn(BoothPageRes.builder()
                         .boothResList(List.of(BoothRes.builder().
                                 build())).build());
@@ -377,6 +367,50 @@ class BoothServiceTest {
         Assertions.assertThat(boothPageRes.getBoothResList()).hasSize(1);
     }
 
+    @DisplayName("부스 게시물들의 운영상태를 변경한다.")
+    @Test
+    void settingBoothStatus() throws Exception {
+        //given
+        LocalDate registeredDate = LocalDate.of(2023, 11, 15);
+        given(boothRepository.findByStartDateEqualsAndOperateStatusEquals(registeredDate, OperateStatus.UPCOMING))
+                .willReturn(List.of(getBooth()));
+        given(boothRepository.findByEndDateEquals(registeredDate)).willReturn(List.of(getBooth()));
+
+        //when
+        boothService.settingBoothStatus(registeredDate);
+
+        //then
+        Assertions.assertThat(getBooth().getOperateStatus()).isEqualTo(OperateStatus.OPERATE);
+    }
+
+    @DisplayName("부스 게시물의 조회수를 증가시킨다.")
+    @Test
+    void increaseBoothViewCount() throws Exception {
+        //given
+        Booth booth = getBooth();
+
+        given(boothRepository.findById(1L)).willReturn(Optional.of(booth));
+
+        //when
+        boothService.increaseBoothViewCount(1L, 1L);
+
+        //then
+        Assertions.assertThat(booth.getViewCount()).isEqualTo(1L);
+    }
+
+    @DisplayName("키워드를 제목에 포함하고 있는 부스 게시물들을 조회한다.")
+    @Test
+    void searchBoothList() throws Exception {
+        //given
+        given(boothRepository.searchBoothList("부스")).willReturn(List.of());
+
+        //when
+        List<BoothSearchRes> boothSearchResList = boothService.searchBoothList("부스");
+
+        //then
+        Assertions.assertThat(boothSearchResList).hasSize(0);
+    }
+
     private Booth getBooth(){
         Booth booth = Booth.builder()
                 .title("부스 게시물 제목")
@@ -391,7 +425,7 @@ class BoothServiceTest {
         return booth;
     }
     private BoothReq getBoothCreateReq() throws IOException {
-        BoothReq boothReq = BoothReq.builder()
+        return BoothReq.builder()
                 .title("푸드트럭 게시물 제목")
                 .subTitle("푸드트럭 게시물 부제목")
                 .operateStatus("OPERATE")
@@ -404,10 +438,9 @@ class BoothServiceTest {
                 .subFiles(List.of(generateMockImageFile("subFile1"), generateMockImageFile("subFile1")))
                 .type("FOOD_TRUCK")
                 .build();
-        return boothReq;
     }
     private BoothReq getBoothUpdateReq() throws IOException {
-        BoothReq boothReq = BoothReq.builder()
+        return BoothReq.builder()
                 .title("변경된 제목")
                 .subTitle("변경된 부제목")
                 .operateStatus("OPERATE")
@@ -418,7 +451,6 @@ class BoothServiceTest {
                 .subFiles(List.of(generateMockImageFile("subFile1"), generateMockImageFile("subFile1")))
                 .type("FOOD_TRUCK")
                 .build();
-        return boothReq;
     }
 
     private Image createImage() {

--- a/src/test/java/com/festival/domain/guide/model/GuideTest.java
+++ b/src/test/java/com/festival/domain/guide/model/GuideTest.java
@@ -19,4 +19,19 @@ class GuideTest {
         //then
         assertThat(guide.isDeleted()).isFalse();
     }
+
+    @DisplayName("안내사항 게시물의 조회수가 입력된 만큼 증가한다.")
+    @Test
+    void increaseViewCount() throws Exception {
+        //given
+        Guide guide = Guide.of(GuideReq.builder()
+                .content("test1")
+                .build());
+
+        //when
+        guide.increaseViewCount(3L);
+
+        //then
+        assertThat(guide.getViewCount()).isEqualTo(3L);
+    }
 }

--- a/src/test/java/com/festival/domain/member/controller/MemberIntegrationTest.java
+++ b/src/test/java/com/festival/domain/member/controller/MemberIntegrationTest.java
@@ -26,7 +26,6 @@ class MemberIntegrationTest extends ControllerTestSupport {
 
     @Autowired
     private MemberService memberService;
-/*
 
     @DisplayName("유저는 회원가입을 할 수 있다.")
     @Test
@@ -76,7 +75,6 @@ class MemberIntegrationTest extends ControllerTestSupport {
                 .andExpect(status().isConflict())
                 .andReturn();
     }
-*/
 
     @DisplayName("회원가입한 사용자는 로그인을 할 수 있다.")
     @Test
@@ -112,4 +110,5 @@ class MemberIntegrationTest extends ControllerTestSupport {
         assertThat(jwtTokenRes.getRefreshToken()).isNotNull();
         assertThat(jwtTokenRes.getTokenType()).isEqualTo("Bearer");
     }
+
 }

--- a/src/test/java/com/festival/domain/program/repository/ProgramRepositoryTest.java
+++ b/src/test/java/com/festival/domain/program/repository/ProgramRepositoryTest.java
@@ -1,0 +1,158 @@
+package com.festival.domain.program.repository;
+
+import com.festival.domain.image.model.Image;
+import com.festival.domain.program.dto.ProgramPageRes;
+import com.festival.domain.program.dto.ProgramSearchRes;
+import com.festival.domain.program.model.Program;
+import com.festival.domain.program.service.vo.ProgramSearchCond;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.festival.common.base.OperateStatus.OPERATE;
+import static com.festival.common.base.OperateStatus.UPCOMING;
+import static com.festival.domain.program.model.ProgramType.EVENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class ProgramRepositoryTest {
+
+    @Autowired
+    private ProgramRepository programRepository;
+
+    @DisplayName("작일과 같으면서 운영중인 프로그램을 조회한다.")
+    @Test
+    void findByStartDateEqualsAndOperateStatusEquals() throws Exception {
+        //given
+        LocalDate startDate = LocalDate.of(2023, 11, 14);
+        LocalDate endDate = LocalDate.of(2023, 11, 15);
+
+        Program program1 = createdProgram(startDate, endDate, "title1");
+        Program program2 = createdProgram(startDate, endDate, "title2");
+        Program program3 = createdProgram(startDate, endDate, "title3");
+        programRepository.saveAllAndFlush(List.of(program1, program2, program3));
+
+        //when
+        List<Program> programs = programRepository.findByStartDateEqualsAndOperateStatusEquals(startDate, OPERATE);
+
+        //then
+        assertThat(programs).hasSize(3)
+                .extracting("title", "subTitle")
+                .containsExactlyInAnyOrder(
+                        tuple("title1", "title1"),
+                        tuple("title2", "title2"),
+                        tuple("title3", "title3")
+                );
+    }
+
+    @DisplayName("종료일이 같은 프로그램을 조회한다.")
+    @Test
+    void findByEndDateEquals() throws Exception {
+        //given
+        LocalDate startDate = LocalDate.of(2023, 11, 14);
+        LocalDate endDate = LocalDate.of(2023, 11, 15);
+
+        Program program1 = createdProgram(startDate, endDate, "title1");
+        Program program2 = createdProgram(startDate, endDate, "title2");
+        Program program3 = createdProgram(startDate, endDate, "title3");
+        programRepository.saveAllAndFlush(List.of(program1, program2, program3));
+
+        //when
+        List<Program> programs = programRepository.findByEndDateEquals(endDate);
+
+        //then
+        assertThat(programs).hasSize(3)
+                .extracting("title", "subTitle")
+                .containsExactlyInAnyOrder(
+                        tuple("title1", "title1"),
+                        tuple("title2", "title2"),
+                        tuple("title3", "title3")
+                );
+    }
+
+    @DisplayName("프로그램 리스트를 조회한다.")
+    @Test
+    void getProgramList() throws Exception {
+        //given
+        LocalDate startDate = LocalDate.of(2023, 11, 14);
+        LocalDate endDate = LocalDate.of(2023, 11, 15);
+
+        Program program1 = createdProgram(startDate, endDate, "title1");
+        Program program2 = createdProgram(startDate, endDate, "title2");
+        Program program3 = createdProgram(startDate, endDate, "title3");
+        programRepository.saveAllAndFlush(List.of(program1, program2, program3));
+
+        //when
+        ProgramSearchCond programSearchCond = ProgramSearchCond.builder()
+                .type(EVENT.getValue())
+                .pageable(PageRequest.of(0, 6))
+                .build();
+        ProgramPageRes programPageRes = programRepository.getProgramList(programSearchCond);
+
+        //then
+        assertThat(programPageRes.getProgramList()).hasSize(3)
+                .extracting("title", "subTitle")
+                .containsExactlyInAnyOrder(
+                        tuple("title1", "title1"),
+                        tuple("title2", "title2"),
+                        tuple("title3", "title3")
+                );
+        assertThat(programPageRes.getPageNumber()).isEqualTo(0);
+        assertThat(programPageRes.getPageSize()).isEqualTo(6);
+        assertThat(programPageRes.getTotalCount()).isEqualTo(3);
+        assertThat(programPageRes.getTotalPage()).isEqualTo(1);
+    }
+
+    @DisplayName("키워드가 포함된 이름의 프로그램 리스트를 조회한다. 이때 운영중인 프로그램만 조회한다.")
+    @Test
+    void searchProgramList() throws Exception {
+        //given
+        LocalDate startDate = LocalDate.of(2023, 11, 14);
+        LocalDate endDate = LocalDate.of(2023, 11, 15);
+
+        Program program1 = createdProgram(startDate, endDate, "title1");
+        Program program2 = createdProgram(startDate, endDate, "title2");
+        Program program3 = createdProgram(startDate, endDate, "title3");
+        programRepository.saveAllAndFlush(List.of(program1, program2, program3));
+
+        //when
+        String keyword = "title2";
+        List<ProgramSearchRes> programSearchRes = programRepository.searchProgramList(keyword);
+
+        //then
+        assertThat(programSearchRes).hasSize(1)
+                .extracting("title", "subTitle", "operateStatus", "mainFilePath")
+                .containsExactlyInAnyOrder(
+                        tuple("title2", "title2", "OPERATE", "mainFilePath")
+                );
+    }
+
+    private Program createdProgram(LocalDate startDate, LocalDate endDate, String title) {
+        Program program = Program.builder()
+                .title(title)
+                .subTitle(title)
+                .content("content")
+                .latitude(1.0f)
+                .longitude(1.0f)
+                .type(EVENT)
+                .operateStatus(OPERATE)
+                .startDate(startDate)
+                .endDate(endDate)
+                .deleted(false)
+                .build();
+        program.setImage(Image.builder()
+                .mainFilePath("mainFilePath")
+                .subFilePaths(List.of("subFilePaths"))
+                .build());
+        return program;
+    }
+
+}

--- a/src/test/java/com/festival/domain/viewcount/model/HomeTest.java
+++ b/src/test/java/com/festival/domain/viewcount/model/HomeTest.java
@@ -15,6 +15,7 @@ class HomeTest {
 
         //then
         assertThat(home.getCount()).isEqualTo(0);
+        assertThat(home.getId()).isZero();
     }
 
     @DisplayName("조회수 객체의 조회수는 더해진만큼 조회수가 증가한다.")


### PR DESCRIPTION
# Issue
- #411 

# Issue 내용
- 추가된 로직에 대한 테스트 케이스들을 작성했습니다. (Booth, Program, Member, ...)
- 몇몇의 축약된 메소드명과 변수명을 수정하였습니다.
  - status -> operateStatus
  - getList -> getProgramList
  - getList -> getBoothList


- querydsl 구문에서 날짜가 null일때 쿼리 생성을 방지해야하는데, 방지하지 못하는 부분을 테스트를 통해 확인하였습니다. 따라서 해당 부분을 서비스단에서 처리하도록 수정하였습니다.
 ### 리팩토링 전 (위치: TimeTableRepositoryImpl)
    private static BooleanExpression isWithinPeriod(LocalDateTime startTime, LocalDateTime endTime) {
          if (startTime == null || endTime == null) {
              return null;
          }
          return timeTable.startTime.goe(startTime)
                  .and(timeTable.endTime.loe(endTime));
    }

  ### 리팩토링 후 (위치: TimeTableService)
    public List<TimeTableRes> getTimeTableList(TimeTableDateReq timeTableDateReq) {
          if (timeTableDateReq.getStartTime() == null || timeTableDateReq.getEndTime() == null) {
              throw new NotFoundException(ErrorCode.INVALID_PARAMETER);
          }
          TimeTableSearchCond timeTableSearchCond =TimeTableSearchCond.builder()
                  .startTime(timeTableDateReq.getStartTime())
                  .endTime(timeTableDateReq.getEndTime())
                  .build();
          return timeTableRepository.getList(timeTableSearchCond);
    }


- 클래스별로 미사용 라이브러리들을 제거하였습니다.
- 파라미터가 부족할 때 사용할 에러코드 하나를 추가하였습니다.
  - `INVALID_PARAMETER("필수 파라미터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST)`
- lombok의 메소드가 테스트에서 제외되도록 설정하였습니다.
- 테스트가 불필요하다고 생각하는 Config, Dto, Vo 클래스들을 테스트에서 제외하였습니다.
- jacoco report 생성을 자동화 하였습니다. 이제 전체 테스트를 실행하고 자동으로 report 를 생성합니다.