### PR TITLE
[#414] 실시간 에러감지를 위한 메신져 알림 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     // Embedded Redis
     testImplementation ('it.ozimov:embedded-redis:0.7.2') { exclude group: "org.slf4j", module: "slf4j-simple" }
     implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+
+    // Slack
+    implementation 'com.slack.api:slack-api-client:1.29.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/festival/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/festival/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.festival.common.exception;
 
+import com.festival.common.infra.Alert.discord.DiscordService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -14,17 +17,22 @@ import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     @Value("${spring.servlet.multipart.max-file-size}")
     private String maxFileSize;
 
+    //    private final SlackService slackService;
+    private final DiscordService discordService;
+
     /**
      * 서비스 로직 도중 발생하는 에러들을 커스텀하여 응답값을 내려줍니다.
      */
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e){
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request){
         ErrorCode errorCode = e.getErrorCode();
+        discordService.sendDiscordAlertLog(e, request);
         log.error(errorCode.getMessage());
         return ResponseEntity.status(errorCode.getStatus()).body( new ErrorResponse(errorCode.getMessage()));
     }
@@ -32,7 +40,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ErrorResponse> handleMaxSizeException() {
         String errorMessage = maxFileSize + " 이내 용량의 파일들만 업로드 할 수 있습니다.";
-        log.error(errorMessage);
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse(errorMessage));
     }
@@ -46,7 +53,6 @@ public class GlobalExceptionHandler {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors()
                 .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
-        log.error(ex.getMessage());
         return ResponseEntity.badRequest().body(errors);
     }
 

--- a/src/main/java/com/festival/common/infra/Alert/discord/DiscordService.java
+++ b/src/main/java/com/festival/common/infra/Alert/discord/DiscordService.java
@@ -1,0 +1,49 @@
+package com.festival.common.infra.Alert.discord;
+
+import com.festival.common.exception.CustomException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordService {
+
+    @Value("${webhook.discord.url}")
+    private String discordUrl;
+
+    public void sendDiscordAlertLog(CustomException ex, HttpServletRequest request) {
+        try {
+            DiscordUtil discordUtil = new DiscordUtil(discordUrl);
+            String registeredTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(LocalDateTime.now());
+
+            discordUtil.setUsername("Millicon");
+            discordUtil.setAvatarUrl("https://raw.githubusercontent.com/angelSooho/InfraTest/main/images/millicon-black.png");
+
+            DiscordUtil.EmbedObject embedObject = new DiscordUtil.EmbedObject()
+                    .setTitle("\uD83D\uDEA8 서버에 에러가 감지되었습니다. 즉시 확인이 필요합니다. \uD83D\uDEA8")
+                    .setColor(Color.RED)
+//                    .setFooter("여기는 footer 입니다 ", "https://i.imgur.com/Hv0xNBm.jpeg") //  푸터
+//                    .setThumbnail("https://i.imgur.com/oBPXx0D.png") //  썸네일 이미지
+//                    .setImage("https://i.imgur.com/8nLFCVP.png") //  메인 이미지
+                    .addField("Request IP", request.getRemoteAddr(), true)
+                    .addField("Request URL", request.getRequestURL() + "   " + request.getMethod(), true)
+                    .addField("Error Code", ex.getErrorCode().getStatus().toString(), false)
+                    .addField("Error Message", ex.getErrorCode().getMessage(), true)
+                    .addField("발생 시간", registeredTimeFormat, false);
+
+            discordUtil.addEmbed(embedObject);
+            discordUtil.execute();
+        } catch (Exception e) {
+            log.debug("Discord 통신 과정에 예외 발생");
+        }
+    }
+
+}

--- a/src/main/java/com/festival/common/infra/Alert/discord/DiscordUtil.java
+++ b/src/main/java/com/festival/common/infra/Alert/discord/DiscordUtil.java
@@ -1,0 +1,277 @@
+package com.festival.common.infra.Alert.discord;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.awt.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.net.URL;
+import java.util.List;
+import java.util.*;
+
+@Setter
+public class DiscordUtil {
+
+    private final String url;
+    private String content;
+    private String username;
+    private String avatarUrl;
+    private boolean tts;
+    private List<EmbedObject> embedObjects = new ArrayList<>();
+
+    public DiscordUtil(String url) {
+        this.url = url;
+    }
+    public void addEmbed(EmbedObject embed) {
+        this.embedObjects.add(embed);
+    }
+
+    public void execute() throws IOException {
+        if (this.content == null && this.embedObjects.isEmpty()) {
+            throw new IllegalArgumentException("Set content or add at least one EmbedObject");
+        }
+
+        JSONObject json = new JSONObject();
+
+        json.put("content", this.content);
+        json.put("username", this.username);
+        json.put("avatar_url", this.avatarUrl);
+        json.put("tts", this.tts);
+
+        if (!this.embedObjects.isEmpty()) {
+            List<JSONObject> embedObjects = new ArrayList<>();
+
+            for (EmbedObject embed : this.embedObjects) {
+                JSONObject jsonEmbed = new JSONObject();
+
+                jsonEmbed.put("title", embed.getTitle());
+                jsonEmbed.put("description", embed.getDescription());
+                jsonEmbed.put("url", embed.getUrl());
+
+                if (embed.getColor() != null) {
+                    Color color = embed.getColor();
+                    int rgb = color.getRed();
+                    rgb = (rgb << 8) + color.getGreen();
+                    rgb = (rgb << 8) + color.getBlue();
+
+                    jsonEmbed.put("color", rgb);
+                }
+
+                EmbedObject.Footer footer = embed.getFooter();
+                EmbedObject.Image image = embed.getImage();
+                EmbedObject.Thumbnail thumbnail = embed.getThumbnail();
+                EmbedObject.Author author = embed.getAuthor();
+                List<EmbedObject.Field> fields = embed.getFields();
+
+                if (footer != null) {
+                    JSONObject jsonFooter = new JSONObject();
+
+                    jsonFooter.put("text", footer.getText());
+                    jsonFooter.put("icon_url", footer.getIconUrl());
+                    jsonEmbed.put("footer", jsonFooter);
+                }
+
+                if (image != null) {
+                    JSONObject jsonImage = new JSONObject();
+
+                    jsonImage.put("url", image.getUrl());
+                    jsonEmbed.put("image", jsonImage);
+                }
+
+                if (thumbnail != null) {
+                    JSONObject jsonThumbnail = new JSONObject();
+
+                    jsonThumbnail.put("url", thumbnail.getUrl());
+                    jsonEmbed.put("thumbnail", jsonThumbnail);
+                }
+
+                if (author != null) {
+                    JSONObject jsonAuthor = new JSONObject();
+
+                    jsonAuthor.put("name", author.getName());
+                    jsonAuthor.put("url", author.getUrl());
+                    jsonAuthor.put("icon_url", author.getIconUrl());
+                    jsonEmbed.put("author", jsonAuthor);
+                }
+
+                List<JSONObject> jsonFields = new ArrayList<>();
+                for (EmbedObject.Field field : fields) {
+                    JSONObject jsonField = new JSONObject();
+
+                    jsonField.put("name", field.getName());
+                    jsonField.put("value", field.getValue());
+                    jsonField.put("inline", field.isInline());
+
+                    jsonFields.add(jsonField);
+                }
+
+                jsonEmbed.put("fields", jsonFields.toArray());
+                embedObjects.add(jsonEmbed);
+            }
+
+            json.put("embeds", embedObjects.toArray());
+        }
+
+        URL url = new URL(this.url);
+        HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+        connection.addRequestProperty("Content-Type", "application/json");
+        connection.addRequestProperty("User-Agent", "Java-DiscordWebhook-BY-Gelox_");
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+
+        OutputStream stream = connection.getOutputStream();
+        stream.write(json.toString().getBytes());
+        stream.flush();
+        stream.close();
+
+        connection.getInputStream().close();
+        connection.disconnect();
+    }
+
+    @Getter
+    public static class EmbedObject {
+        private String title;
+        private String description;
+        private String url;
+        private Color color;
+
+        private Footer footer;
+        private Thumbnail thumbnail;
+        private Image image;
+        private Author author;
+        private List<Field> fields = new ArrayList<>();
+
+        public EmbedObject setTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public EmbedObject setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public EmbedObject setUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public EmbedObject setColor(Color color) {
+            this.color = color;
+            return this;
+        }
+
+        public EmbedObject setFooter(String text, String icon) {
+            this.footer = new Footer(text, icon);
+            return this;
+        }
+
+        public EmbedObject setThumbnail(String url) {
+            this.thumbnail = new Thumbnail(url);
+            return this;
+        }
+
+        public EmbedObject setImage(String url) {
+            this.image = new Image(url);
+            return this;
+        }
+
+        public EmbedObject setAuthor(String name, String url, String icon) {
+            this.author = new Author(name, url, icon);
+            return this;
+        }
+
+        public EmbedObject addField(String name, String value, boolean inline) {
+            this.fields.add(new Field(name, value, inline));
+            return this;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        private class Footer {
+            private String text;
+            private String iconUrl;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        private class Thumbnail {
+            private String url;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        private class Image {
+            private String url;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        private class Author {
+            private String name;
+            private String url;
+            private String iconUrl;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        private class Field {
+            private String name;
+            private String value;
+            private boolean inline;
+        }
+    }
+
+    private class JSONObject {
+
+        private final HashMap<String, Object> map = new HashMap<>();
+
+        void put(String key, Object value) {
+            if (value != null) {
+                map.put(key, value);
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            Set<Map.Entry<String, Object>> entrySet = map.entrySet();
+            builder.append("{");
+
+            int i = 0;
+            for (Map.Entry<String, Object> entry : entrySet) {
+                Object val = entry.getValue();
+                builder.append(quote(entry.getKey())).append(":");
+
+                if (val instanceof String) {
+                    builder.append(quote(String.valueOf(val)));
+                } else if (val instanceof Integer) {
+                    builder.append(Integer.valueOf(String.valueOf(val)));
+                } else if (val instanceof Boolean) {
+                    builder.append(val);
+                } else if (val instanceof JSONObject) {
+                    builder.append(val.toString());
+                } else if (val.getClass().isArray()) {
+                    builder.append("[");
+                    int len = Array.getLength(val);
+                    for (int j = 0; j < len; j++) {
+                        builder.append(Array.get(val, j).toString()).append(j != len - 1 ? "," : "");
+                    }
+                    builder.append("]");
+                }
+
+                builder.append(++i == entrySet.size() ? "}" : ",");
+            }
+
+            return builder.toString();
+        }
+
+        private String quote(String string) {
+            return "\"" + string + "\"";
+        }
+    }
+}

--- a/src/main/java/com/festival/common/infra/Alert/slack/SlackService.java
+++ b/src/main/java/com/festival/common/infra/Alert/slack/SlackService.java
@@ -1,0 +1,66 @@
+package com.festival.common.infra.Alert.slack;
+
+import com.festival.common.exception.CustomException;
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+@Slf4j
+@Component
+public class SlackService {
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${webhook.slack.url}")
+    private String slackUrl;
+
+    public void sendSlackAlertLog(CustomException e, HttpServletRequest request) {
+        try {
+            slackClient.send(slackUrl, payload(p -> p
+                    .text("\uD83D\uDEA8" +
+                            " 서버에 에러가 감지되었습니다. 즉시 확인이 필요합니다. " +
+                            "\uD83D\uDEA8")
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request, LocalDateTime.now()))
+                    )
+            ));
+        } catch (IOException slackError) {
+            log.debug("Slack 통신 과정에 예외 발생");
+        }
+    }
+
+    private Attachment generateSlackAttachment(CustomException e, HttpServletRequest request, LocalDateTime dateTime) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(dateTime);
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + " 발생 에러 로그")
+                .fields(List.of(
+                                generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                                generateSlackField("Request URL", request.getRequestURL() + " " + request.getMethod()),
+                                generateSlackField("Error Code", e.getErrorCode().getStatus().toString()),
+                                generateSlackField("Error Message", e.getErrorCode().getMessage())
+                        )
+                )
+                .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
+    }
+}

--- a/src/main/java/com/festival/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/festival/common/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.festival.common.security.config;
 
+import com.festival.common.infra.Alert.discord.DiscordService;
 import com.festival.common.security.JwtAuthenticationFilter;
 import com.festival.common.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    //    private final SlackService slackService;
+    private final DiscordService discordService;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -44,7 +48,7 @@ public class SecurityConfig {
                 .and()
                 .headers().frameOptions().disable()
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, discordService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,9 @@ custom:
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace
+
+webhook:
+  slack:
+    url: ${custom.webhook.SLACK_DEVELOP_URL}
+  discord:
+    url: ${custom.webhook.DISCORD_DEVELOP_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,3 +10,9 @@ custom:
   redis:
     host: redis_1
     port: 6379
+
+webhook:
+  slack:
+    url: ${custom.webhook.SLACK_PRODUCTION_URL}
+  discord:
+    url: ${custom.webhook.DISCORD_PRODUCTION_URL}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -21,3 +21,9 @@ custom:
   redis:
     host: localhost
     port: 6378
+
+webhook:
+  slack:
+    url: ${custom.webhook.SLACK_DEVELOP_URL}
+  discord:
+    url: ${custom.webhook.DISCORD_DEVELOP_URL}


### PR DESCRIPTION
# Issue
- #414 

# Issue 내용
- DiscordService, SlackService 클래스를 추가하여 각 SNS로 실시간으로 알림을 받을 수 있는 로직을 구현하였습니다.
- 전역예외핸들러 클래스에 예외를 캐치했을 때, 메신져에도 알릴수 있도록 추가하였습니다.
- 인증관련 예외는 전역예외핸들러에서 잡을 수 없어, 직접 인증 로직 중, 예외가 발생한 구역에서 예외를 알릴 수 있도록 추가하였습니다.