### PR TITLE
[#423] 이미지 연관관계 리팩토링

### DIFF
--- a/src/main/java/com/festival/common/util/ImageUtils.java
+++ b/src/main/java/com/festival/common/util/ImageUtils.java
@@ -62,15 +62,12 @@ public class ImageUtils {
         return kind + "_" + UUID.randomUUID() + ext;
     }
 
-    public void deleteFiles(Image image){
+    public void deleteFiles(List<Image> images){
         DeleteObjectRequest deleteObjectRequest;
-        if (image.getMainFilePath() != null) {
-            deleteObjectRequest = new DeleteObjectRequest(bucketName, image.getMainFilePath());
-            amazonS3.deleteObject(deleteObjectRequest);
-        }
-        if (image.getSubFilePaths() != null) {
-            for (String subFile : image.getSubFilePaths()) {
-                deleteObjectRequest = new DeleteObjectRequest(bucketName, subFile);
+
+        if (images != null) {
+            for (Image subFile : images) {
+                deleteObjectRequest = new DeleteObjectRequest(bucketName, subFile.getFilePath());
                 amazonS3.deleteObject(deleteObjectRequest);
             }
         }

--- a/src/main/java/com/festival/domain/booth/controller/dto/BoothRes.java
+++ b/src/main/java/com/festival/domain/booth/controller/dto/BoothRes.java
@@ -1,6 +1,7 @@
 package com.festival.domain.booth.controller.dto;
 
 import com.festival.domain.booth.model.Booth;
+import com.festival.domain.image.model.Image;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,7 +48,7 @@ public class BoothRes {
                 .longitude(booth.getLongitude())
                 .operateStatus(booth.getOperateStatus().getValue())
                 .type(booth.getType().getValue())
-                .mainFilePath(booth.getImage().getMainFilePath())
-                .subFilePaths(booth.getImage().getSubFilePaths()).build();
+                .mainFilePath(booth.getThumbnailImage().getFilePath())
+                .subFilePaths(booth.getImages().stream().map(Image::getFilePath).toList()).build();
     }
 }

--- a/src/main/java/com/festival/domain/booth/model/Booth.java
+++ b/src/main/java/com/festival/domain/booth/model/Booth.java
@@ -11,10 +11,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter
@@ -49,7 +49,10 @@ public class Booth extends BaseEntity {
     private BoothType type;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private Image image;
+    private Image thumbnailImage;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Image> images;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -96,8 +99,11 @@ public class Booth extends BaseEntity {
                 .deleted(false)
                 .type(BoothType.handleType(boothReq.getType())).build();
     }
-    public void setImage(Image image){
-        this.image = image;
+
+    public void setImage(Image thumbnailImage, List<Image> images)
+    {
+        this.thumbnailImage = thumbnailImage;
+        this.images = images;
     }
 
     private static OperateStatus resolveOperateStatus(LocalDate currentDate,String operateStatus,

--- a/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
+++ b/src/main/java/com/festival/domain/booth/repository/impl/BoothRepositoryImpl.java
@@ -38,7 +38,7 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
     public BoothPageRes getBoothList(BoothListSearchCond boothListSearchCond) {
         List<Booth> result = queryFactory
                 .selectFrom(booth)
-                .join(booth.image).fetchJoin()
+                .join(booth.thumbnailImage).fetchJoin()
                 .where(
                         eqType(boothListSearchCond.getType()),
                         booth.deleted.eq(false)
@@ -71,7 +71,7 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
                         booth.title,
                         booth.subTitle,
                         booth.operateStatus.stringValue(),
-                        booth.image.mainFilePath
+                        booth.thumbnailImage.filePath
                ))
                .from(booth)
                .where(

--- a/src/main/java/com/festival/domain/image/model/Image.java
+++ b/src/main/java/com/festival/domain/image/model/Image.java
@@ -1,11 +1,12 @@
 package com.festival.domain.image.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Entity
 @Getter
@@ -15,14 +16,10 @@ public class Image {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String mainFilePath;
-
-    @ElementCollection
-    private List<String> subFilePaths;
+    private String filePath;
 
     @Builder
-    private Image(String mainFilePath, List<String> subFilePaths) {
-        this.mainFilePath = mainFilePath;
-        this.subFilePaths = subFilePaths;
+    private Image(String filePath) {
+        this.filePath = filePath;
     }
 }

--- a/src/main/java/com/festival/domain/image/service/ImageService.java
+++ b/src/main/java/com/festival/domain/image/service/ImageService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,16 +22,21 @@ public class ImageService {
      * @Description
      * 실제 S3와 연동되는 API입니다.
     */
-    public Image uploadImage(MultipartFile mainFile, List<MultipartFile> subFiles, String kind){
-        String mainFilePath = imageUtils.upload(mainFile, kind);
-        List<String> subFilePaths = imageUtils.uploadMulti(subFiles,kind);
+    public Image uploadImage(MultipartFile file, String kind){
+        String filePath = imageUtils.upload(file, kind);
 
         return Image.builder()
-                .mainFilePath(fullEndpoint + mainFilePath)
-                .subFilePaths(subFilePaths.stream()
-                        .map(s -> fullEndpoint + s)
-                        .collect(Collectors.toList())).build();
+                .filePath(fullEndpoint + filePath).build();
     }
+
+    /**
+     * return Image.builder()
+     *                 .mainFilePath(fullEndpoint + mainFilePath)
+     *                 .subFilePaths(subFilePaths.stream()
+     *                         .map(s -> fullEndpoint + s)
+     *                         .collect(Collectors.toList())).build();
+     * */
+
 
     /**
      * @Description
@@ -70,7 +74,8 @@ public class ImageService {
     }
     */
 
-    public void deleteImage(Image image) {
-        imageUtils.deleteFiles(image);
+    public void deleteImage(Image thumbnailImage, List<Image> images) {
+        images.add(thumbnailImage);
+        imageUtils.deleteFiles(images);
     }
 }

--- a/src/main/java/com/festival/domain/program/dto/ProgramRes.java
+++ b/src/main/java/com/festival/domain/program/dto/ProgramRes.java
@@ -1,5 +1,6 @@
 package com.festival.domain.program.dto;
 
+import com.festival.domain.image.model.Image;
 import com.festival.domain.program.model.Program;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,8 +46,8 @@ public class ProgramRes {
                 .operateStatus(program.getOperateStatus().toString())
                 .longitude(program.getLongitude())
                 .latitude(program.getLatitude())
-                .mainFilePath(program.getImage().getMainFilePath())
-                .subFilePaths(program.getImage().getSubFilePaths())
+                .mainFilePath(program.getThumbnailImage().getFilePath())
+                .subFilePaths(program.getImages().stream().map(Image::getFilePath).toList())
                 .build();
     }
 }

--- a/src/main/java/com/festival/domain/program/model/Program.java
+++ b/src/main/java/com/festival/domain/program/model/Program.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,7 +44,10 @@ public class Program extends BaseEntity {
     private ProgramType type;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private Image image;
+    private Image thumbnailImage;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Image> images;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -113,8 +117,9 @@ public class Program extends BaseEntity {
         this.deleted = true;
     }
 
-    public void setImage(Image uploadImage) {
-        this.image = uploadImage;
+    public void setImage(Image thumbnailImage, List<Image> images) {
+        this.thumbnailImage = thumbnailImage;
+        this.images = images;
     }
 
     public void connectMember(Member member){

--- a/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
+++ b/src/main/java/com/festival/domain/program/repository/impl/ProgramRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.festival.domain.program.dto.ProgramPageRes;
 import com.festival.domain.program.dto.ProgramSearchRes;
 import com.festival.domain.program.dto.QProgramSearchRes;
 import com.festival.domain.program.model.Program;
+import com.festival.domain.program.model.QProgram;
 import com.festival.domain.program.repository.ProgramRepositoryCustom;
 import com.festival.domain.program.service.vo.ProgramSearchCond;
 import com.querydsl.core.types.OrderSpecifier;
@@ -38,7 +39,7 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
     public ProgramPageRes getProgramList(ProgramSearchCond programSearchCond) {
         List<Program> result = queryFactory
                 .selectFrom(program)
-                .join(program.image).fetchJoin()
+                .join(program.thumbnailImage).fetchJoin()
                 .where(
                         TypeEq(programSearchCond.getType()),
                         program.deleted.eq(false)
@@ -68,7 +69,7 @@ public class ProgramRepositoryCustomImpl implements ProgramRepositoryCustom {
                         program.title,
                         program.subTitle,
                         program.operateStatus.stringValue(),
-                        program.image.mainFilePath
+                        program.thumbnailImage.filePath
                 ))
                 .from(program)
                 .where(

--- a/src/test/java/com/festival/domain/booth/controller/BoothIntegrationTest.java
+++ b/src/test/java/com/festival/domain/booth/controller/BoothIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.festival.domain.member.model.MemberRole.ADMIN;
@@ -118,9 +119,10 @@ class BoothIntegrationTest extends ControllerTestSupport {
 
         BoothReq boothReq = getBoothReq();
 
-
         Booth booth = Booth.of(boothReq);
-        booth.setImage(createImage());
+
+        booth.setImage(createThumbnailImage(), createImages());
+
         booth.connectMember(member);
         Booth savedBooth = boothRepository.saveAndFlush(booth);
 
@@ -396,12 +398,14 @@ class BoothIntegrationTest extends ControllerTestSupport {
         BoothReq boothReq = getBoothReq();
 
         Booth booth = Booth.of(boothReq);
-        Image image = Image.builder()
-                .mainFilePath(mainFile.getName())
-                .subFilePaths(subFiles.stream().map(MockMultipartFile::getName).toList())
-                .build();
+
+        Image thumbnailImage = Image.builder().filePath(mainFile.getName()).build();
+        List<String> list = subFiles.stream().map(MockMultipartFile::getName).toList();
+        List<Image> images = list.stream().map(filePath -> Image.builder().filePath(filePath).build()).toList();
+
         booth.connectMember(member);
-        booth.setImage(image);
+        booth.setImage(thumbnailImage, images);
+
         Booth savedBooth = boothRepository.saveAndFlush(booth);
 
         //when
@@ -493,13 +497,16 @@ class BoothIntegrationTest extends ControllerTestSupport {
                 .operateStatus("OPERATE")
                 .build();
         Booth booth = Booth.of(boothReq);
-        Image image = Image.builder()
-                .mainFilePath(mainFile.getName())
-                .subFilePaths(subFiles.stream().map(MockMultipartFile::getName).toList())
-                .build();
+
+
+        Image thumbnailImage = Image.builder().filePath(mainFile.getName()).build();
+        List<String> list = subFiles.stream().map(MockMultipartFile::getName).toList();
+        List<Image> images = list.stream().map(filePath -> Image.builder().filePath(filePath).build()).toList();
+
         booth.connectMember(member);
-        booth.setImage(image);
-        Booth booth11 = booth;
+        booth.setImage(thumbnailImage, images);
+
+
         return boothRepository.saveAndFlush(booth);
     }
 
@@ -529,10 +536,19 @@ class BoothIntegrationTest extends ControllerTestSupport {
         );
     }
 
-    private Image createImage() {
+    private Image createThumbnailImage() {
         return Image.builder()
-                .mainFilePath("/mainFile")
-                .subFilePaths(List.of("/subFile1", "/subFile2"))
+                .filePath("/mainFile")
                 .build();
+    }
+    private List<Image> createImages() {
+        List<Image> images = new ArrayList<>();
+        for(String filePath : List.of("/subFile1", "/subFile2")) {
+            images.add(Image.builder()
+                    .filePath(filePath)
+                    .build()
+            );
+        }
+        return images;
     }
 }

--- a/src/test/java/com/festival/domain/booth/repository/BoothRepositoryTest.java
+++ b/src/test/java/com/festival/domain/booth/repository/BoothRepositoryTest.java
@@ -133,9 +133,11 @@ class BoothRepositoryTest {
                 .deleted(false)
                 .build();
         booth.setImage(Image.builder()
-                .mainFilePath("mainFilePath")
-                .subFilePaths(List.of("subFilePaths"))
-                .build());
+                        .filePath("mainFilePath")
+                        .build(),
+                List.of(Image.builder()
+                        .filePath("subFilePath")
+                        .build()));
         return booth;
     }
 }

--- a/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
+++ b/src/test/java/com/festival/domain/booth/service/BoothServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -334,7 +335,8 @@ class BoothServiceTest {
     void getBoothTest(){
         //given
         Booth foodTruck = BoothFixture.FOOD_TRUCK;
-        ReflectionTestUtils.setField(foodTruck, "image", createImage());
+        ReflectionTestUtils.setField(foodTruck, "thumbnailImage", createThumbnailImage());
+        ReflectionTestUtils.setField(foodTruck, "images", createImages());
 
         given(boothRepository.findById(1L))
                 .willReturn(Optional.of(foodTruck));
@@ -453,10 +455,19 @@ class BoothServiceTest {
                 .build();
     }
 
-    private Image createImage() {
+    private Image createThumbnailImage() {
         return Image.builder()
-                .mainFilePath("/mainFile")
-                .subFilePaths(List.of("/subFile1", "/subFile2"))
+                .filePath("/mainFile")
                 .build();
+    }
+    private List<Image> createImages() {
+        List<Image> images = new ArrayList<>();
+        for(String filePath : List.of("/subFile1", "/subFile2")) {
+            images.add(Image.builder()
+                    .filePath(filePath)
+                    .build()
+            );
+        }
+        return images;
     }
 }

--- a/src/test/java/com/festival/domain/program/controller/ProgramIntegrationTest.java
+++ b/src/test/java/com/festival/domain/program/controller/ProgramIntegrationTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.festival.domain.member.model.MemberRole.ADMIN;
@@ -145,6 +146,9 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 TestImageUtils.generateMockImageFile("subFiles")
         );
 
+        Image image = createImage();
+        List<Image> images = createImages();
+
         ProgramReq programReq = ProgramReq.builder()
                 .title("title")
                 .subTitle("subTitle")
@@ -158,7 +162,7 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 .endDate(registeredEndDate)
                 .build();
         Program program = Program.of(programReq, LocalDate.now());
-        program.setImage(createImage());
+        program.setImage(image, images);
         program.connectMember(member);
         Program savedProgram = programRepository.saveAndFlush(program);
 
@@ -447,11 +451,9 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 .build();
         Program program = Program.of(programReq, registeredDate);
         program.connectMember(member);
-        Image image = Image.builder()
-                .mainFilePath("mainFilePath")
-                .subFilePaths(List.of("subFilePath1", "subFilePath2", "subFilePath3"))
-                .build();
-        program.setImage(image);
+        Image image = createImage();
+        List<Image> images = createImages();
+        program.setImage(image, images);
         Program savedProgram = programRepository.saveAndFlush(program);
 
         //when
@@ -487,10 +489,8 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 TestImageUtils.generateMockImageFile("subFiles")
         );
 
-        Image image = Image.builder()
-                .mainFilePath("mainFilePath")
-                .subFilePaths(List.of("subFilePath1", "subFilePath2", "subFilePath3"))
-                .build();
+        Image image = createImage();
+        List<Image> images = createImages();
 
         ProgramReq programReq = ProgramReq.builder()
                 .title("title")
@@ -506,25 +506,25 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 .build();
         Program program1 = Program.of(programReq, registeredDate);
         program1.connectMember(member);
-        program1.setImage(image);
+        program1.setImage(image, images);
         Program program2 = Program.of(programReq, registeredDate);
         program2.connectMember(member);
-        program2.setImage(image);
+        program2.setImage(image, images);
         Program program3 = Program.of(programReq, registeredDate);
         program3.connectMember(member);
-        program3.setImage(image);
+        program3.setImage(image, images);
         Program program4 = Program.of(programReq, registeredDate);
         program4.connectMember(member);
-        program4.setImage(image);
+        program4.setImage(image, images);
         Program program5 = Program.of(programReq, registeredDate);
         program5.connectMember(member);
-        program5.setImage(image);
+        program5.setImage(image, images);
         Program program6 = Program.of(programReq, registeredDate);
         program6.connectMember(member);
-        program6.setImage(image);
+        program6.setImage(image, images);
         Program program7 = Program.of(programReq, registeredDate);
         program7.connectMember(member);
-        program7.setImage(image);
+        program7.setImage(image, images);
 
         programRepository.saveAll(List.of(program1, program2, program3, program4, program5,
                 program6, program7));
@@ -593,11 +593,6 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 TestImageUtils.generateMockImageFile("subFiles")
         );
 
-        Image image = Image.builder()
-                .mainFilePath("mainFilePath")
-                .subFilePaths(List.of("subFilePath1", "subFilePath2", "subFilePath3"))
-                .build();
-
         ProgramReq programReq = ProgramReq.builder()
                 .title("includeTitle")
                 .subTitle("subTitle")
@@ -612,16 +607,20 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 .build();
         Program program1 = Program.of(programReq, registeredDate);
         program1.connectMember(member);
-        program1.setImage(image);
+
+        Image image = createImage();
+        List<Image> images = createImages();
+
+        program1.setImage(image, images);
         Program program2 = Program.of(programReq, registeredDate);
         program2.connectMember(member);
-        program2.setImage(image);
+        program2.setImage(image, images);
         Program program3 = Program.of(programReq, registeredDate);
         program3.connectMember(member);
-        program3.setImage(image);
+        program3.setImage(image, images);
         Program program4 = Program.of(programReq, registeredDate);
         program4.connectMember(member);
-        program4.setImage(image);
+        program4.setImage(image, images);
 
         programReq = ProgramReq.builder()
                 .title("notMatched")
@@ -637,13 +636,13 @@ class ProgramIntegrationTest extends ControllerTestSupport {
                 .build();
         Program program5 = Program.of(programReq, registeredDate);
         program5.connectMember(member);
-        program5.setImage(image);
+        program5.setImage(image, images);
         Program program6 = Program.of(programReq, registeredDate);
         program6.connectMember(member);
-        program6.setImage(image);
+        program6.setImage(image, images);
         Program program7 = Program.of(programReq, registeredDate);
         program7.connectMember(member);
-        program7.setImage(image);
+        program7.setImage(image, images);
 
         programRepository.saveAll(List.of(program1, program2, program3, program4, program5,
                 program6, program7));
@@ -696,9 +695,15 @@ class ProgramIntegrationTest extends ControllerTestSupport {
 
     private Image createImage() {
         return Image.builder()
-                .mainFilePath("/mainFile")
-                .subFilePaths(List.of("/subFile1", "/subFile2"))
+                .filePath("mainFilePath")
                 .build();
     }
 
+    private List<Image> createImages() {
+        List<Image> images = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            images.add(createImage());
+        }
+        return images;
+    }
 }

--- a/src/test/java/com/festival/domain/program/repository/ProgramRepositoryTest.java
+++ b/src/test/java/com/festival/domain/program/repository/ProgramRepositoryTest.java
@@ -148,10 +148,14 @@ class ProgramRepositoryTest {
                 .endDate(endDate)
                 .deleted(false)
                 .build();
-        program.setImage(Image.builder()
-                .mainFilePath("mainFilePath")
-                .subFilePaths(List.of("subFilePaths"))
-                .build());
+        program.setImage(
+            Image.builder()
+                    .filePath("mainFilePath")
+                    .build(),
+            List.of(Image.builder()
+                    .filePath("subFilePath")
+                    .build())
+        );
         return program;
     }
 


### PR DESCRIPTION
# Issue
- #423 

# Issue 내용
- Image 객체 리팩토링을 진행했습니다.
  - 기존 코드로는 Image 객체 안에서 서브 Image들이 전부 메인 Image의 id로 매핑이 되고 있어서 컬렉션의 관리가 매우 복잡해지는 이슈가 있었습니다.
  - 추가로 임의의 Image 를 삭제하는 요구사항을 충족할 수 없었습니다.
  - 따라서 Image 객체를 선택하여 관리할 수 있도록 @ElementCollection을 사용하지 않고, Image 객체를 사용하는 도메인 객체에서 필드를 구분하여 Image를 사용하도록 하여, 관리작업이 수월하도록 개선하였습니다.
- Image 객체 리팩토링에 따른 테스트 코드 수정
  - 구조가 바뀌다 보니 에러가 발생하는 테스트 코드에 대해 수정작업을 진행하였습니다.

# Refactoring 전
    @ElementCollection
    private List<String> subFilePaths;
- 기존 이미지 객체 내부에서 서브 이미지 관리법

# Refactoring 후
    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
    private Image thumbnailImage;

    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
    private List<Image> images;
- 도메인 객체 필드로 분리